### PR TITLE
Add a basic search feature

### DIFF
--- a/openfoodfacts/products.py
+++ b/openfoodfacts/products.py
@@ -31,8 +31,16 @@ def get_by_facets(query):
         return utils.fetch('/'.join(path))['products']
 
 
-def search(query, pagination=20):
+def search(query, page=1, page_size=20, sort_by='unique_scans'):
     """
     Perform a search using Open Food Facts search engine.
     """
-    pass
+    path = "cgi/search.pl?search_terms={query}&json=1&" + \
+           "page={page}&page_size={page_size}&sort_by={sort_by}"
+    path = path.format(
+        query=query,
+        page=page,
+        page_size=page_size,
+        sort_by=sort_by
+    )
+    return utils.fetch(path, json_file=False)

--- a/openfoodfacts/utils.py
+++ b/openfoodfacts/utils.py
@@ -16,12 +16,22 @@ def fetch(path, json_file=True):
     response = requests.get(path)
     return response.json()
 
-def get_ocr_json_url_for_an_image(first_three_digits, second_three_digits, third_three_digits,fourth_three_digits, image_name):
+
+def get_ocr_json_url_for_an_image(first_three_digits,
+                                  second_three_digits,
+                                  third_three_digits,
+                                  fourth_three_digits,
+                                  image_name):
     """
-    Get the URL of a JSON file given a barcode in 4 chunks of 3 digits and an image name (1, 2, 3, front_fr…)
+    Get the URL of a JSON file given a barcode in 4 chunks of 3 digits and an
+    image name (1, 2, 3, front_fr...).
     """
-	try:
-		image_ocr_json = "http://world.openfoodfacts.org/images/products/" + str(first_three_digits)+ "/" + str(second_three_digits)+ "/" + str(third_three_digits)+ "/" + str(fourth_three_digits)+ "/" + str(image_name) + ".json"
-		return str(image_ocr_json)
-	except IndexError:
-		return None
+    url = "http://world.openfoodfacts.org/images/products/"
+    url += "%s/%s/%s/%s/%s.json" % (
+        first_three_digits,
+        second_three_digits,
+        third_three_digits,
+        fourth_three_digits,
+        image_name
+    )
+    return url

--- a/openfoodfacts/utils.py
+++ b/openfoodfacts/utils.py
@@ -3,10 +3,15 @@ import requests
 API_URL = "http://world.openfoodfacts.org/"
 
 
-def fetch(path):
+def fetch(path, json_file=True):
     """
     Fetch data at a given path assuming that target match a json file and is
     located on the OFF API.
     """
-    response = requests.get("%s%s.json" % (API_URL, path))
+    if json_file:
+        path = "%s%s.json" % (API_URL, path)
+    else:
+        path = "%s%s" % (API_URL, path)
+
+    response = requests.get(path)
     return response.json()

--- a/tests/products_test.py
+++ b/tests/products_test.py
@@ -41,6 +41,23 @@ class TestProducts(unittest.TestCase):
                     {'trace': 'egg', 'country': 'france'})
             self.assertEquals(res, ["omelet"])
 
+    def test_search(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'http://world.openfoodfacts.org/cgi/search.pl?' +
+                'search_terms=kinder bueno&json=1&page=' +
+                '1&page_size=20&sort_by=unique_scans',
+                text='{"products":["kinder bueno"], "count": 1}')
+            res = openfoodfacts.products.search('kinder bueno')
+            self.assertEquals(res["products"],  ["kinder bueno"])
+            mock.get(
+                'http://world.openfoodfacts.org/cgi/search.pl?' +
+                'search_terms=banania&json=1&page=' +
+                '2&page_size=10&sort_by=unique_scans',
+                text='{"products":["banania", "banania big"], "count": 2}')
+            res = openfoodfacts.products.search(
+                'banania', page=2, page_size=10)
+            self.assertEquals(res["products"],  ["banania", "banania big"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix #8 

The idea is to allow developers to perform basic search through the Python API.
It doesn't cover all capabilities of the API. I prefer to have real life use cases before implementing anything complex.

Reference: http://en.wiki.openfoodfacts.org/API#Searching_for_products
