### PR TITLE
Added data download function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,13 @@ or:
     sudo python setup.py install
 
 
-### Docs
+### Docs
 
-#### Facets
+*Login into Openfoodfacts*
+
+```login_session_object = openfoodfacts.utils.login_into_OFF()```
+
+#### Facets
 
 *Get all available additives.*
 
@@ -239,5 +243,8 @@ products = openfoodfacts.products.get_by_state(state)
 product = openfoodfacts.products.get_product(barcode)
 ```
 
+*Open Food Facts data exports*
+
+```openfoodfacts.utils.download_data(file_type)```
 
 

--- a/openfoodfacts/utils.py
+++ b/openfoodfacts/utils.py
@@ -28,6 +28,35 @@ def login_into_OFF():
         # Return the session object
         return c
 
+    
+def download_data(file_type='mongodb'):
+    """
+    Fetch data from Openfoodfacts server. Options mongodb, csv, rdf.
+    The file is downloded in the current directory.
+    """
+    if file_type == 'mongodb':
+
+        file_url = "https://world.openfoodfacts.org/data/openfoodfacts-mongodbdump.tar.gz"
+        filename = "openfoodfacts-mongodbdump.tar.gz"
+
+    elif file_type == 'csv':
+
+        file_url = "https://world.openfoodfacts.org/data/en.openfoodfacts.org.products.csv"
+        filename = "en.openfoodfacts.org.products.csv"
+    elif file_type == 'rdf':
+
+        file_url = "https://world.openfoodfacts.org/data/en.openfoodfacts.org.products.rdf"
+        filename = "en.openfoodfacts.org.products.rdf"
+
+    request_content = requests.get(file_url, stream=True)
+
+    with open(filename, "wb") as file:
+        for chunk in request_content.iter_content(chunk_size=1024):
+
+            # writing one chunk at a time to the file
+            if chunk:
+                file.write(chunk)
+                
 
 def fetch(path, json_file=True):
     """


### PR DESCRIPTION
**Summary**

Added functionality to download all Open Food Facts data exports

**How to run?**

Just call the function ``openfoodfacts.utils.download_data(file_type)``

Fetch data from Openfoodfacts server. Options mongodb, csv, rdf.
The file is downloaded in the current directory.