### PR TITLE
Allow to upload photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ status_code = openfoodfacts.products.add_new_product({
 })
 ```
 
+*Upload an image.*
+
+```
+status_code = openfoodfacts.products.upload_image(barcode, imagefield, img_path)
+```
 
 #### Search
 

--- a/openfoodfacts/products.py
+++ b/openfoodfacts/products.py
@@ -45,6 +45,36 @@ def add_new_product(postData, locale='world'):
         post(utils.API_URL % (locale)+"cgi/product_jqm2.pl", data=postData)
 
 
+def upload_image(code, imagefield, path):
+    """
+    Add new image for a product
+    """
+    if imagefield == 'front':
+        image_payload = {"imgupload_front": open(path, 'rb')}
+
+    elif imagefield == 'ingredients':
+        image_payload = {"imgupload_ingredients": open(path, 'rb')}
+
+    elif imagefield == 'nutrition':
+        image_payload = {"imgupload_nutrition": open(path, 'rb')}
+
+    else:
+        raise ValueError("Imagefield not valid!")
+
+    url = "https://world.openfoodfacts.org/cgi/product_image_upload.pl"
+
+    other_payload = {'code': code, 'imagefield': imagefield}
+
+    headers = {'Content-Type': 'multipart/form-data'}
+
+    request_content = requests.post(url=url,
+                                    data=other_payload,
+                                    files=image_payload,
+                                    headers=headers)
+
+    return request_content
+
+
 def search(query, page=1, page_size=20,
            sort_by='unique_scans', locale='world'):
     """

--- a/openfoodfacts/products.py
+++ b/openfoodfacts/products.py
@@ -45,18 +45,18 @@ def add_new_product(postData, locale='world'):
         post(utils.API_URL % (locale)+"cgi/product_jqm2.pl", data=postData)
 
 
-def upload_image(code, imagefield, path):
+def upload_image(code, imagefield, img_path):
     """
     Add new image for a product
     """
     if imagefield == 'front':
-        image_payload = {"imgupload_front": open(path, 'rb')}
+        image_payload = {"imgupload_front": open(img_path, 'rb')}
 
     elif imagefield == 'ingredients':
-        image_payload = {"imgupload_ingredients": open(path, 'rb')}
+        image_payload = {"imgupload_ingredients": open(img_path, 'rb')}
 
     elif imagefield == 'nutrition':
-        image_payload = {"imgupload_nutrition": open(path, 'rb')}
+        image_payload = {"imgupload_nutrition": open(img_path, 'rb')}
 
     else:
         raise ValueError("Imagefield not valid!")


### PR DESCRIPTION
**Problem**
Currently, there is no way to upload images using the python client

**Solution**
Added image upload function. Just call
```
request_content = openfoodfacts.products.upload_image(barcode, imagefield, img_path)
```

Fix #25 