### PR TITLE
Add generator for search, get_by ...

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -15,6 +15,7 @@ This guide provides information on the API. All the I/O is [JSON](www.json.org).
 ## Open Food Facts
 
 #### Login
+
 *Login into Openfoodfacts*
 
 ```login_session_object = openfoodfacts.utils.login_into_OFF()```
@@ -118,10 +119,27 @@ products = openfoodfacts.products.get_by_facets({
 })
 ```
 
+To get all products for given facets without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_by_facets({
+  'trace': 'egg',
+  'country': 'france'
+}):
+    print (product['product_name'])
+```
+
 *Get all products for given additive.*
 
 ```python
 products = openfoodfacts.products.get_by_additive(additive, page=1)
+```
+
+To get all products for given additive without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_additive(additive):
+    print (product['product_name'])
 ```
 
 *Get all products for given allergen.*
@@ -130,10 +148,24 @@ products = openfoodfacts.products.get_by_additive(additive, page=1)
 products = openfoodfacts.products.get_by_allergen(allergen)
 ```
 
+To get all products for given allergen without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_allergen(allergen):
+    print (product['product_name'])
+```
+
 *Get all products for given brand.*
 
 ```python
 products = openfoodfacts.products.get_by_brand(brand)
+```
+
+To get all products for given brand without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_brand(brand):
+    print (product['product_name'])
 ```
 
 *Get all products for given category.*
@@ -142,10 +174,24 @@ products = openfoodfacts.products.get_by_brand(brand)
 products = openfoodfacts.products.get_by_category(category)
 ```
 
+To get all products for given category without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_category(category):
+    print (product['product_name'])
+```
+
 *Get all products for given country.*
 
 ```python
 products = openfoodfacts.products.get_by_country(country)
+```
+
+To get all products for given country without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_country(country):
+    print (product['product_name'])
 ```
 
 *Get all products for given entry date.*
@@ -154,10 +200,24 @@ products = openfoodfacts.products.get_by_country(country)
 products = openfoodfacts.products.get_by_entry_date(entry_date)
 ```
 
+To get all products for given entry date without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_entry_date(entry_date):
+    print (product['product_name'])
+```
+
 *Get all products for given ingredient.*
 
 ```python
 products = openfoodfacts.products.get_by_ingredient(ingredient)
+```
+
+To get all products for given ingredient without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_ingredient(ingredient):
+    print (product['product_name'])
 ```
 
 *Get all products for given language.*
@@ -166,10 +226,24 @@ products = openfoodfacts.products.get_by_ingredient(ingredient)
 products = openfoodfacts.products.get_by_language(language)
 ```
 
+To get all products for given language without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_language(language):
+    print (product['product_name'])
+```
+
 *Get all products for given packaging.*
 
 ```python
 products = openfoodfacts.products.get_by_packaging(packaging)
+```
+
+To get all products for given packaging without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_packaging(packaging):
+    print (product['product_name'])
 ```
 
 *Get all products for given packaging code.*
@@ -178,10 +252,24 @@ products = openfoodfacts.products.get_by_packaging(packaging)
 products = openfoodfacts.products.get_by_packaging_code(code)
 ```
 
+To get all products for given packaging code without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_packaging_code(packaging_code):
+    print (product['product_name'])
+```
+
 *Get all products for given purchase place.*
 
 ```python
 products = openfoodfacts.products.get_by_purchase_place(place)
+```
+
+To get all products for given purchase place without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_purchase_place(purchase_place):
+    print (product['product_name'])
 ```
 
 *Get all products for given store.*
@@ -190,10 +278,24 @@ products = openfoodfacts.products.get_by_purchase_place(place)
 products = openfoodfacts.products.get_by_store(store)
 ```
 
+To get all products for given store without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_store(store):
+    print (product['product_name'])
+```
+
 *Get all products for given trace type.*
 
 ```python
 products = openfoodfacts.products.get_by_trace(trace)
+```
+
+To get all products for given trace type without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_trace_type(trace_type):
+    print (product['product_name'])
 ```
 
 *Get all products for given state.*
@@ -202,6 +304,12 @@ products = openfoodfacts.products.get_by_trace(trace)
 products = openfoodfacts.products.get_by_state(state)
 ```
 
+To get all products for given state without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.get_all_by_state(state):
+    print (product['product_name'])
+```
 
 #### Product
 
@@ -213,7 +321,7 @@ product = openfoodfacts.products.get_product(barcode)
 
 *Open Food Facts data exports*
 
-```
+```python
 openfoodfacts.utils.download_data(file_type)
 ```
 
@@ -243,6 +351,13 @@ status_code = openfoodfacts.products.upload_image(barcode, imagefield, img_path)
 
 ```python
 search_result = openfoodfacts.products.search(query)
+```
+
+To get all products without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.products.search_all(query):
+    print (product['product_name'])
 ```
 
 *Advanced Search*
@@ -282,10 +397,27 @@ products = openfoodfacts.openbeautyfacts.get_by_facets({
 })
 ```
 
+To get all products for given facets without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.openbeautyfacts.get_all_by_facets({
+  'packaging': 'Plastique',
+  'country': 'france'
+}):
+    print (product['product_name'])
+```
+
 *Basic Search*
 
-```
+```python
 search_result = openfoodfacts.openbeautyfacts.products.search(query)
+```
+
+To get all products without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.openbeautyfacts.products.search(query):
+    print (product['product_name'])
 ```
 
 ## Open Pet Food Facts
@@ -307,9 +439,25 @@ products = openfoodfacts.openpetfoodfacts.get_by_facets({
 })
 ```
 
+To get all products for given facets without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.openpetfoodfacts.get_all_by_facets({
+  'brand': 'Sans marque',
+  'country': 'france'
+}):
+    print (product['product_name'])
+```
+
 *Basic Search*
 
-```
+```python
 search_result = openfoodfacts.openpetfoodfacts.search(query)
 ```
 
+To get all products without pagination (returns a generator):
+
+```python
+for product in openfoodfacts.openpetfoodfacts.search_all(query):
+    print (product['product_name'])
+```

--- a/openfoodfacts/__init__.py
+++ b/openfoodfacts/__init__.py
@@ -48,6 +48,10 @@ def add_by_facet_fetch_function(facet):
     Usage example for egg trace:
 
         openfoodfacts.products.get_by_trace(egg)
+
+    Using a generator:
+
+        openfoodfacts.products.get_all_by_trace(egg)
     """
     if facet[-3:] == 'ies':
         facet = facet[:-3] + 'y'
@@ -63,6 +67,21 @@ def add_by_facet_fetch_function(facet):
 
     func.__name__ = "get_by_%s" % facet
     setattr(products, func.__name__, func)
+
+    def func_all(facet_id, locale='world'):
+        page = 1
+        while True:
+            path = utils.build_url(geography=locale,
+                                   resource_type=[facet, facet_id, str(page)])
+            products = utils.fetch(path)['products']
+            if not products:
+                break
+            for product in products:
+                yield product
+            page += 1
+
+    func_all.__name__ = "get_all_by_%s" % facet
+    setattr(products, func_all.__name__, func_all)
 
 
 # Build a fetch function for each facet.

--- a/openfoodfacts/openbeautyfacts.py
+++ b/openfoodfacts/openbeautyfacts.py
@@ -69,4 +69,4 @@ def search_all(query, sort_by='unique_scans', locale='world'):
     Perform a search using Open Beauty Facts search engine using a generator.
     """
     return utils.get_all(search, query,
-                         page_size=20, sort_by=sort_by,locale=locale)
+                         page_size=20, sort_by=sort_by, locale=locale)

--- a/openfoodfacts/openbeautyfacts.py
+++ b/openfoodfacts/openbeautyfacts.py
@@ -41,7 +41,7 @@ def get_all_by_facets(query, locale='world'):
     """
     Return products for a set of facets using a generator.
     """
-    return utils.get_all(get_by_facets, query, locale=locale)
+    return utils.get_all(get_by_facets, None, query, locale=locale)
 
 
 def search(query, page=1, page_size=20,
@@ -61,12 +61,12 @@ def search(query, page=1, page_size=20,
                            parameters=parameters,
                            entity="beauty")
 
-    return utils.fetch(path, json_file=False)['products']
+    return utils.fetch(path, json_file=False)
 
 
 def search_all(query, sort_by='unique_scans', locale='world'):
     """
     Perform a search using Open Beauty Facts search engine using a generator.
     """
-    return utils.get_all(search, query,
+    return utils.get_all(search, 'products', query,
                          page_size=20, sort_by=sort_by, locale=locale)

--- a/openfoodfacts/openbeautyfacts.py
+++ b/openfoodfacts/openbeautyfacts.py
@@ -37,6 +37,13 @@ def get_by_facets(query, page=1, locale='world'):
                                   entity="beauty"))['products']
 
 
+def get_all_by_facets(query, locale='world'):
+    """
+    Return products for a set of facets using a generator.
+    """
+    return utils.get_all(get_by_facets, query, locale=locale)
+
+
 def search(query, page=1, page_size=20,
            sort_by='unique_scans', locale='world'):
     """
@@ -54,4 +61,12 @@ def search(query, page=1, page_size=20,
                            parameters=parameters,
                            entity="beauty")
 
-    return utils.fetch(path, json_file=False)
+    return utils.fetch(path, json_file=False)['products']
+
+
+def search_all(query, sort_by='unique_scans', locale='world'):
+    """
+    Perform a search using Open Beauty Facts search engine using a generator.
+    """
+    return utils.get_all(search, query,
+                         page_size=20, sort_by=sort_by,locale=locale)

--- a/openfoodfacts/openpetfoodfacts.py
+++ b/openfoodfacts/openpetfoodfacts.py
@@ -41,7 +41,7 @@ def get_all_by_facets(query, locale='world'):
     """
     Return products for a set of facets using a generator.
     """
-    return utils.get_all(get_by_facets, query, locale=locale)
+    return utils.get_all(get_by_facets, None, query, locale=locale)
 
 
 def search(query, page=1, page_size=20,
@@ -61,12 +61,12 @@ def search(query, page=1, page_size=20,
                            parameters=parameters,
                            entity="pet")
 
-    return utils.fetch(path, json_file=False)['products']
+    return utils.fetch(path, json_file=False)
 
 
 def search_all(query, sort_by='unique_scans', locale='world'):
     """
     Perform a search using Open Pet Food Facts search engine using a generator.
     """
-    return utils.get_all(search, query,
+    return utils.get_all(search, 'products', query,
                          page_size=20, sort_by=sort_by, locale=locale)

--- a/openfoodfacts/openpetfoodfacts.py
+++ b/openfoodfacts/openpetfoodfacts.py
@@ -69,4 +69,4 @@ def search_all(query, sort_by='unique_scans', locale='world'):
     Perform a search using Open Pet Food Facts search engine using a generator.
     """
     return utils.get_all(search, query,
-                         page_size=20, sort_by=sort_by,locale=locale)
+                         page_size=20, sort_by=sort_by, locale=locale)

--- a/openfoodfacts/openpetfoodfacts.py
+++ b/openfoodfacts/openpetfoodfacts.py
@@ -37,6 +37,13 @@ def get_by_facets(query, page=1, locale='world'):
                                   entity="pet"))['products']
 
 
+def get_all_by_facets(query, locale='world'):
+    """
+    Return products for a set of facets using a generator.
+    """
+    return utils.get_all(get_by_facets, query, locale=locale)
+
+
 def search(query, page=1, page_size=20,
            sort_by='unique_scans', locale='world'):
     """
@@ -54,4 +61,12 @@ def search(query, page=1, page_size=20,
                            parameters=parameters,
                            entity="pet")
 
-    return utils.fetch(path, json_file=False)
+    return utils.fetch(path, json_file=False)['products']
+
+
+def search_all(query, sort_by='unique_scans', locale='world'):
+    """
+    Perform a search using Open Pet Food Facts search engine using a generator.
+    """
+    return utils.get_all(search, query,
+                         page_size=20, sort_by=sort_by,locale=locale)

--- a/openfoodfacts/products.py
+++ b/openfoodfacts/products.py
@@ -40,7 +40,7 @@ def get_all_by_facets(query, locale='world'):
     """
     Return products for a set of facets using a generator.
     """
-    return utils.get_all(get_by_facets, query, locale=locale)
+    return utils.get_all(get_by_facets, None, query, locale=locale)
 
 
 def add_new_product(post_data, locale='world'):
@@ -94,14 +94,14 @@ def search(query, page=1, page_size=20,
                           resource_type='search.pl',
                           parameters=parameters)
 
-    return utils.fetch(url, json_file=False)['products']
+    return utils.fetch(url, json_file=False)
 
 
 def search_all(query, sort_by='unique_scans', locale='world'):
     """
     Perform a search using Open Food Facts search engine using a generator.
     """
-    return utils.get_all(search, query,
+    return utils.get_all(search, 'products', query,
                          page_size=20, sort_by=sort_by, locale=locale)
 
 

--- a/openfoodfacts/products.py
+++ b/openfoodfacts/products.py
@@ -102,7 +102,7 @@ def search_all(query, sort_by='unique_scans', locale='world'):
     Perform a search using Open Food Facts search engine using a generator.
     """
     return utils.get_all(search, query,
-                         page_size=20, sort_by=sort_by,locale=locale)
+                         page_size=20, sort_by=sort_by, locale=locale)
 
 
 def advanced_search(post_query):

--- a/openfoodfacts/products.py
+++ b/openfoodfacts/products.py
@@ -36,6 +36,13 @@ def get_by_facets(query, page=1, locale='world'):
         return utils.fetch(url)['products']
 
 
+def get_all_by_facets(query, locale='world'):
+    """
+    Return products for a set of facets using a generator.
+    """
+    return utils.get_all(get_by_facets, query, locale=locale)
+
+
 def add_new_product(post_data, locale='world'):
     """
     Add a new product to OFF database.
@@ -87,7 +94,15 @@ def search(query, page=1, page_size=20,
                           resource_type='search.pl',
                           parameters=parameters)
 
-    return utils.fetch(url, json_file=False)
+    return utils.fetch(url, json_file=False)['products']
+
+
+def search_all(query, sort_by='unique_scans', locale='world'):
+    """
+    Perform a search using Open Food Facts search engine using a generator.
+    """
+    return utils.get_all(search, query,
+                         page_size=20, sort_by=sort_by,locale=locale)
 
 
 def advanced_search(post_query):

--- a/openfoodfacts/utils.py
+++ b/openfoodfacts/utils.py
@@ -137,12 +137,14 @@ def get_ocr_json_url_for_an_image(first_three_digits,
     return url
 
 
-def get_all(func, *args, **kwargs):
+def get_all(func, key, *args, **kwargs):
     kwargs['page'] = 1
     while True:
-        products = func(*args, **kwargs)
-        if not products:
+        elements = func(*args, **kwargs)
+        if key and key in elements:
+            elements = elements[key]
+        if not elements:
             break
-        for product in products:
-            yield product
+        for element in elements:
+            yield element
         kwargs['page'] += 1

--- a/openfoodfacts/utils.py
+++ b/openfoodfacts/utils.py
@@ -113,7 +113,7 @@ def fetch(path, json_file=True):
     """
     if json_file:
         path = "%s.json" % (path)
-
+    print (path)
     response = requests.get(path)
     return response.json()
 
@@ -136,3 +136,14 @@ def get_ocr_json_url_for_an_image(first_three_digits,
         image_name
     )
     return url
+
+
+def get_all(func, *args, **kwargs):
+    kwargs['page'] = 1
+    while True:
+        products = func(*args, **kwargs)
+        if not products:
+            break
+        for product in products:
+            yield product
+        kwargs['page'] += 1

--- a/openfoodfacts/utils.py
+++ b/openfoodfacts/utils.py
@@ -113,7 +113,6 @@ def fetch(path, json_file=True):
     """
     if json_file:
         path = "%s.json" % (path)
-    print (path)
     response = requests.get(path)
     return response.json()
 

--- a/tests/beautyproducts_test.py
+++ b/tests/beautyproducts_test.py
@@ -1,0 +1,92 @@
+import unittest
+import os
+import openfoodfacts
+import requests
+import requests_mock
+
+
+class TestBeautyProducts(unittest.TestCase):
+
+    def test_get_product(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openbeautyfacts.org/api/v0/product/1223435.json',
+                text='{"name":"product_beauty_test"}')
+            res = openfoodfacts.openbeautyfacts.get_product('1223435')
+            self.assertEqual(res, {'name': 'product_beauty_test'})
+
+    def test_get_by_country_and_trace(self):
+        res = openfoodfacts.openbeautyfacts.get_by_facets({})
+        self.assertEqual(res, [])
+
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openbeautyfacts.org/country/'
+                'france/packaging/plastique/1.json',
+                text='{"products":["déodorant"]}')
+            res = openfoodfacts.openbeautyfacts.get_by_facets(
+                    {'packaging': 'Plastique', 'country': 'france'})
+            self.assertEqual(res, ["déodorant"])
+
+    def test_get_by_country_and_trace_all(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openbeautyfacts.org/brand/'
+                'Sans%20marque/country/france/1.json',
+                text='{"products":["déodorant"], "count": 1}')
+            mock.get(
+                'https://world.openbeautyfacts.org/brand/'
+                'Sans%20marque/country/france/2.json',
+                text='{"products":["déodorant small", "déodorant big"], "count": 2}')
+            mock.get(
+                'https://world.openbeautyfacts.org/brand/'
+                'Sans%20marque/country/france/3.json',
+                text='{"products":[], "count": 0}')
+            res = openfoodfacts.openbeautyfacts.get_all_by_facets(
+                    {'brand': 'Sans marque', 'country': 'france'})
+            expected_products_sequence = ["déodorant", "déodorant small", "déodorant big"]
+            for i, product in enumerate(res):
+                self.assertEqual(product, expected_products_sequence[i])
+
+    def test_search(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openbeautyfacts.org/cgi/search.pl?' +
+                'search_terms=deo axe&json=1&page=' +
+                '1&page_size=20&sort_by=unique_scans',
+                text='{"products":["deo axe"], "count": 1}')
+            res = openfoodfacts.openbeautyfacts.search('deo axe')
+            self.assertEqual(res['products'],  ["deo axe"])
+            mock.get(
+                'https://world.openbeautyfacts.org/cgi/search.pl?' +
+                'search_terms=deo axe&json=1&page=' +
+                '2&page_size=10&sort_by=unique_scans',
+                text='{"products":["deo axe", "deo axe big"], "count": 2}')
+            res = openfoodfacts.openbeautyfacts.search('deo axe', page=2, page_size=10)
+            self.assertEqual(res['products'],  ["deo axe", "deo axe big"])
+
+    def test_search_all(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openbeautyfacts.org/cgi/search.pl?' +
+                'search_terms=deo axe&json=1&page=' +
+                '1&page_size=20&sort_by=unique_scans',
+                text='{"products":["deo axe small"], "count": 1}')
+            mock.get(
+                'https://world.openbeautyfacts.org/cgi/search.pl?' +
+                'search_terms=deo axe&json=1&page=' +
+                '2&page_size=20&sort_by=unique_scans',
+                text='{"products":["deo axe", "deo axe big"], "count": 2}')
+            mock.get(
+                'https://world.openbeautyfacts.org/cgi/search.pl?' +
+                'search_terms=deo axe&json=1&page=' +
+                '3&page_size=20&sort_by=unique_scans',
+                text='{"products":[], "count": 2}')
+            res = openfoodfacts.openbeautyfacts.search_all('deo axe')
+            expected_products_sequence = ["deo axe small", "deo axe", "deo axe big"]
+            for i, product in enumerate(res):
+                self.assertEqual(product, expected_products_sequence[i])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/beautyproducts_test.py
+++ b/tests/beautyproducts_test.py
@@ -23,28 +23,28 @@ class TestBeautyProducts(unittest.TestCase):
             mock.get(
                 'https://world.openbeautyfacts.org/country/'
                 'france/packaging/plastique/1.json',
-                text='{"products":["déodorant"]}')
+                text='{"products":["parfum"]}')
             res = openfoodfacts.openbeautyfacts.get_by_facets(
                     {'packaging': 'Plastique', 'country': 'france'})
-            self.assertEqual(res, ["déodorant"])
+            self.assertEqual(res, ["parfum"])
 
     def test_get_by_country_and_trace_all(self):
         with requests_mock.mock() as mock:
             mock.get(
                 'https://world.openbeautyfacts.org/brand/'
                 'Sans%20marque/country/france/1.json',
-                text='{"products":["déodorant"], "count": 1}')
+                text='{"products":["parfum"], "count": 1}')
             mock.get(
                 'https://world.openbeautyfacts.org/brand/'
                 'Sans%20marque/country/france/2.json',
-                text='{"products":["déodorant small", "déodorant big"], "count": 2}')
+                text='{"products":["parfum small", "parfum big"], "count": 2}')
             mock.get(
                 'https://world.openbeautyfacts.org/brand/'
                 'Sans%20marque/country/france/3.json',
                 text='{"products":[], "count": 0}')
             res = openfoodfacts.openbeautyfacts.get_all_by_facets(
                     {'brand': 'Sans marque', 'country': 'france'})
-            expected_products_sequence = ["déodorant", "déodorant small", "déodorant big"]
+            expected_products_sequence = ["parfum", "parfum small", "parfum big"]
             for i, product in enumerate(res):
                 self.assertEqual(product, expected_products_sequence[i])
 

--- a/tests/petproducts_test.py
+++ b/tests/petproducts_test.py
@@ -1,0 +1,92 @@
+import unittest
+import os
+import openfoodfacts
+import requests
+import requests_mock
+
+
+class TestPetProducts(unittest.TestCase):
+
+    def test_get_product(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openpetfoodfacts.org/api/v0/product/1223435.json',
+                text='{"name":"product_test"}')
+            res = openfoodfacts.openpetfoodfacts.get_product('1223435')
+            self.assertEqual(res, {'name': 'product_test'})
+
+    def test_get_by_country_and_trace(self):
+        res = openfoodfacts.openpetfoodfacts.get_by_facets({})
+        self.assertEqual(res, [])
+
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openpetfoodfacts.org/brand/'
+                'Sans%20marque/country/france/1.json',
+                text='{"products":["croquants"]}')
+            res = openfoodfacts.openpetfoodfacts.get_by_facets(
+                    {'brand': 'Sans marque', 'country': 'france'})
+            self.assertEqual(res, ["croquants"])
+
+    def test_get_by_country_and_trace_all(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openpetfoodfacts.org/brand/'
+                'Sans%20marque/country/france/1.json',
+                text='{"products":["croquants"], "count": 1}')
+            mock.get(
+                'https://world.openpetfoodfacts.org/brand/'
+                'Sans%20marque/country/france/2.json',
+                text='{"products":["croquants small", "croquants big"], "count": 2}')
+            mock.get(
+                'https://world.openpetfoodfacts.org/brand/'
+                'Sans%20marque/country/france/3.json',
+                text='{"products":[], "count": 0}')
+            res = openfoodfacts.openpetfoodfacts.get_all_by_facets(
+                    {'brand': 'Sans marque', 'country': 'france'})
+            expected_products_sequence = ["croquants", "croquants small", "croquants big"]
+            for i, product in enumerate(res):
+                self.assertEqual(product, expected_products_sequence[i])
+
+    def test_search(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openpetfoodfacts.org/cgi/search.pl?' +
+                'search_terms=le chat&json=1&page=' +
+                '1&page_size=20&sort_by=unique_scans',
+                text='{"products":["le chat"], "count": 1}')
+            res = openfoodfacts.openpetfoodfacts.search('le chat')
+            self.assertEqual(res['products'],  ["le chat"])
+            mock.get(
+                'https://world.openpetfoodfacts.org/cgi/search.pl?' +
+                'search_terms=croquants&json=1&page=' +
+                '2&page_size=10&sort_by=unique_scans',
+                text='{"products":["croquants", "croquants big"], "count": 2}')
+            res = openfoodfacts.openpetfoodfacts.search('croquants', page=2, page_size=10)
+            self.assertEqual(res['products'],  ["croquants", "croquants big"])
+
+    def test_search_all(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openpetfoodfacts.org/cgi/search.pl?' +
+                'search_terms=croquants&json=1&page=' +
+                '1&page_size=20&sort_by=unique_scans',
+                text='{"products":["croquants small"], "count": 1}')
+            mock.get(
+                'https://world.openpetfoodfacts.org/cgi/search.pl?' +
+                'search_terms=croquants&json=1&page=' +
+                '2&page_size=20&sort_by=unique_scans',
+                text='{"products":["croquants", "croquants big"], "count": 2}')
+            mock.get(
+                'https://world.openpetfoodfacts.org/cgi/search.pl?' +
+                'search_terms=croquants&json=1&page=' +
+                '3&page_size=20&sort_by=unique_scans',
+                text='{"products":[], "count": 2}')
+            res = openfoodfacts.openpetfoodfacts.search_all('croquants')
+            expected_products_sequence = ["croquants small", "croquants", "croquants big"]
+            for i, product in enumerate(res):
+                self.assertEqual(product, expected_products_sequence[i])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/products_test.py
+++ b/tests/products_test.py
@@ -65,6 +65,26 @@ class TestProducts(unittest.TestCase):
                     {'trace': 'egg', 'country': 'france'})
             self.assertEqual(res, ["omelet"])
 
+    def test_get_by_country_and_trace_all(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openfoodfacts.org/country/'
+                'france/trace/egg/1.json',
+                text='{"products":["omelet"], "count": 1}')
+            mock.get(
+                'https://world.openfoodfacts.org/country/'
+                'france/trace/egg/2.json',
+                text='{"products":["omelet small", "omelet big"], "count": 2}')
+            mock.get(
+                'https://world.openfoodfacts.org/country/'
+                'france/trace/egg/3.json',
+                text='{"products":[], "count": 0}')
+            res = openfoodfacts.products.get_all_by_facets(
+                    {'trace': 'egg', 'country': 'france'})
+            expected_products_sequence = ["omelet", "omelet small", "omelet big"]
+            for i, product in enumerate(res):
+                self.assertEqual(product, expected_products_sequence[i])
+
     def test_search(self):
         with requests_mock.mock() as mock:
             mock.get(
@@ -73,14 +93,14 @@ class TestProducts(unittest.TestCase):
                 '1&page_size=20&sort_by=unique_scans',
                 text='{"products":["kinder bueno"], "count": 1}')
             res = openfoodfacts.products.search('kinder bueno')
-            self.assertEqual(res,  ["kinder bueno"])
+            self.assertEqual(res['products'],  ["kinder bueno"])
             mock.get(
                 'https://world.openfoodfacts.org/cgi/search.pl?' +
                 'search_terms=banania&json=1&page=' +
                 '2&page_size=10&sort_by=unique_scans',
                 text='{"products":["banania", "banania big"], "count": 2}')
             res = openfoodfacts.products.search('banania', page=2, page_size=10)
-            self.assertEqual(res,  ["banania", "banania big"])
+            self.assertEqual(res['products'],  ["banania", "banania big"])
 
     def test_search_all(self):
         with requests_mock.mock() as mock:

--- a/tests/products_test.py
+++ b/tests/products_test.py
@@ -36,6 +36,22 @@ class TestProducts(unittest.TestCase):
             res = openfoodfacts.products.get_by_country('france')
             self.assertEqual(res, ["omelet"])
 
+    def test_get_all_by_country(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openfoodfacts.org/country/france/1.json',
+                text='{"products":["kinder bueno"], "count": 1}')
+            mock.get(
+                'https://world.openfoodfacts.org/country/france/2.json',
+                text='{"products":["banania", "banania big"], "count": 2}')
+            mock.get(
+                'https://world.openfoodfacts.org/country/france/3.json',
+                text='{"products":[], "count": 0}')
+            res = openfoodfacts.products.get_all_by_country('france')
+            expected_products_sequence = ["kinder bueno", "banania", "banania big"]
+            for i, product in enumerate(res):
+                self.assertEqual(product, expected_products_sequence[i])
+
     def test_get_by_country_and_trace(self):
         res = openfoodfacts.products.get_by_facets({})
         self.assertEqual(res, [])
@@ -57,15 +73,36 @@ class TestProducts(unittest.TestCase):
                 '1&page_size=20&sort_by=unique_scans',
                 text='{"products":["kinder bueno"], "count": 1}')
             res = openfoodfacts.products.search('kinder bueno')
-            self.assertEqual(res["products"],  ["kinder bueno"])
+            self.assertEqual(res,  ["kinder bueno"])
             mock.get(
                 'https://world.openfoodfacts.org/cgi/search.pl?' +
                 'search_terms=banania&json=1&page=' +
                 '2&page_size=10&sort_by=unique_scans',
                 text='{"products":["banania", "banania big"], "count": 2}')
-            res = openfoodfacts.products.search(
-                'banania', page=2, page_size=10)
-            self.assertEqual(res["products"],  ["banania", "banania big"])
+            res = openfoodfacts.products.search('banania', page=2, page_size=10)
+            self.assertEqual(res,  ["banania", "banania big"])
+
+    def test_search_all(self):
+        with requests_mock.mock() as mock:
+            mock.get(
+                'https://world.openfoodfacts.org/cgi/search.pl?' +
+                'search_terms=banania&json=1&page=' +
+                '1&page_size=20&sort_by=unique_scans',
+                text='{"products":["banania small"], "count": 1}')
+            mock.get(
+                'https://world.openfoodfacts.org/cgi/search.pl?' +
+                'search_terms=banania&json=1&page=' +
+                '2&page_size=20&sort_by=unique_scans',
+                text='{"products":["banania", "banania big"], "count": 2}')
+            mock.get(
+                'https://world.openfoodfacts.org/cgi/search.pl?' +
+                'search_terms=banania&json=1&page=' +
+                '3&page_size=20&sort_by=unique_scans',
+                text='{"products":[], "count": 2}')
+            res = openfoodfacts.products.search_all('banania')
+            expected_products_sequence = ["banania small", "banania", "banania big"]
+            for i, product in enumerate(res):
+                self.assertEqual(product, expected_products_sequence[i])
 
     def test_advanced_search(self):
         with requests_mock.mock() as mock:


### PR DESCRIPTION
This PR adds some useful methods to generate all the products during a `search` or a `get_by` call for OFF, OPF and OBF without having to specify a page if you need to list them all, for example

```py
for product in openfoodfacts.products.get_all_by_country('italy'):
    print (product.get('product_name', 'Unknown'))

for product in openfoodfacts.products.get_all_by_facets({'trace': 'eggs', 'country': 'france'}):
    print (product.get('product_name', 'Unknown'))

for product in openfoodfacts.products.search_all('kinder bueno'):
    print (product.get('product_name', 'Unknown'))
```

This feature is a work in progress because I need to:

- document this methods under `docs/Usage.md`
- write some tests for OPF and OBF

@frankrousseau I also modified the `search` method to make it returning only the products

```py
return utils.fetch(url, json_file=False)['products']
```

I can revert this change if it breaks something and write a custom `search_all` without using `search`.


