### PR TITLE
Use pet_products and beauty_products as aliases

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -383,7 +383,7 @@ search_result = openfoodfacts.products.advanced_search({
 *Get a given product.*
 
 ```python
-product = openfoodfacts.openbeautyfacts.get_product(barcode)
+product = openfoodfacts.beauty_products.get_product(barcode)
 ```
 
 *Get all products for given facets.*
@@ -391,7 +391,7 @@ product = openfoodfacts.openbeautyfacts.get_product(barcode)
 Page access (pagination) is available through parameters.
 
 ```python
-products = openfoodfacts.openbeautyfacts.get_by_facets({
+products = openfoodfacts.beauty_products.get_by_facets({
   'packaging': 'Plastique',
   'country': 'france'
 })
@@ -400,7 +400,7 @@ products = openfoodfacts.openbeautyfacts.get_by_facets({
 To get all products for given facets without pagination (returns a generator):
 
 ```python
-for product in openfoodfacts.openbeautyfacts.get_all_by_facets({
+for product in openfoodfacts.beauty_products.get_all_by_facets({
   'packaging': 'Plastique',
   'country': 'france'
 }):
@@ -410,13 +410,13 @@ for product in openfoodfacts.openbeautyfacts.get_all_by_facets({
 *Basic Search*
 
 ```python
-search_result = openfoodfacts.openbeautyfacts.products.search(query)
+search_result = openfoodfacts.beauty_products.products.search(query)
 ```
 
 To get all products without pagination (returns a generator):
 
 ```python
-for product in openfoodfacts.openbeautyfacts.products.search(query):
+for product in openfoodfacts.beauty_products.products.search(query):
     print (product['product_name'])
 ```
 
@@ -425,7 +425,7 @@ for product in openfoodfacts.openbeautyfacts.products.search(query):
 *Get a given product.*
 
 ```python
-product = openfoodfacts.openpetfoodfacts.get_product(barcode)
+product = openfoodfacts.pet_products.get_product(barcode)
 ```
 
 *Get all products for given facets.*
@@ -433,7 +433,7 @@ product = openfoodfacts.openpetfoodfacts.get_product(barcode)
 Page access (pagination) is available through parameters.
 
 ```python
-products = openfoodfacts.openpetfoodfacts.get_by_facets({
+products = openfoodfacts.pet_products.get_by_facets({
   'brand': 'Sans marque',
   'country': 'france'
 })
@@ -442,7 +442,7 @@ products = openfoodfacts.openpetfoodfacts.get_by_facets({
 To get all products for given facets without pagination (returns a generator):
 
 ```python
-for product in openfoodfacts.openpetfoodfacts.get_all_by_facets({
+for product in openfoodfacts.pet_products.get_all_by_facets({
   'brand': 'Sans marque',
   'country': 'france'
 }):
@@ -452,12 +452,12 @@ for product in openfoodfacts.openpetfoodfacts.get_all_by_facets({
 *Basic Search*
 
 ```python
-search_result = openfoodfacts.openpetfoodfacts.search(query)
+search_result = openfoodfacts.pet_products.search(query)
 ```
 
 To get all products without pagination (returns a generator):
 
 ```python
-for product in openfoodfacts.openpetfoodfacts.search_all(query):
+for product in openfoodfacts.pet_products.search_all(query):
     print (product['product_name'])
 ```

--- a/openfoodfacts/__init__.py
+++ b/openfoodfacts/__init__.py
@@ -3,8 +3,8 @@ import sys
 from . import facets
 from . import utils
 from .products import get_product
-from . import openbeautyfacts
-from . import openpetfoodfacts
+from . import openbeautyfacts as beauty_products
+from . import openpetfoodfacts as pet_products
 
 openfoodfacts = sys.modules[__name__]
 __version__ = '0.1.0'

--- a/tests/beautyproducts_test.py
+++ b/tests/beautyproducts_test.py
@@ -12,11 +12,11 @@ class TestBeautyProducts(unittest.TestCase):
             mock.get(
                 'https://world.openbeautyfacts.org/api/v0/product/1223435.json',
                 text='{"name":"product_beauty_test"}')
-            res = openfoodfacts.openbeautyfacts.get_product('1223435')
+            res = openfoodfacts.beauty_products.get_product('1223435')
             self.assertEqual(res, {'name': 'product_beauty_test'})
 
     def test_get_by_country_and_trace(self):
-        res = openfoodfacts.openbeautyfacts.get_by_facets({})
+        res = openfoodfacts.beauty_products.get_by_facets({})
         self.assertEqual(res, [])
 
         with requests_mock.mock() as mock:
@@ -24,7 +24,7 @@ class TestBeautyProducts(unittest.TestCase):
                 'https://world.openbeautyfacts.org/country/'
                 'france/packaging/plastique/1.json',
                 text='{"products":["parfum"]}')
-            res = openfoodfacts.openbeautyfacts.get_by_facets(
+            res = openfoodfacts.beauty_products.get_by_facets(
                     {'packaging': 'Plastique', 'country': 'france'})
             self.assertEqual(res, ["parfum"])
 
@@ -42,7 +42,7 @@ class TestBeautyProducts(unittest.TestCase):
                 'https://world.openbeautyfacts.org/brand/'
                 'Sans%20marque/country/france/3.json',
                 text='{"products":[], "count": 0}')
-            res = openfoodfacts.openbeautyfacts.get_all_by_facets(
+            res = openfoodfacts.beauty_products.get_all_by_facets(
                     {'brand': 'Sans marque', 'country': 'france'})
             expected_products_sequence = ["parfum", "parfum small", "parfum big"]
             for i, product in enumerate(res):
@@ -55,14 +55,14 @@ class TestBeautyProducts(unittest.TestCase):
                 'search_terms=deo axe&json=1&page=' +
                 '1&page_size=20&sort_by=unique_scans',
                 text='{"products":["deo axe"], "count": 1}')
-            res = openfoodfacts.openbeautyfacts.search('deo axe')
+            res = openfoodfacts.beauty_products.search('deo axe')
             self.assertEqual(res['products'],  ["deo axe"])
             mock.get(
                 'https://world.openbeautyfacts.org/cgi/search.pl?' +
                 'search_terms=deo axe&json=1&page=' +
                 '2&page_size=10&sort_by=unique_scans',
                 text='{"products":["deo axe", "deo axe big"], "count": 2}')
-            res = openfoodfacts.openbeautyfacts.search('deo axe', page=2, page_size=10)
+            res = openfoodfacts.beauty_products.search('deo axe', page=2, page_size=10)
             self.assertEqual(res['products'],  ["deo axe", "deo axe big"])
 
     def test_search_all(self):
@@ -82,7 +82,7 @@ class TestBeautyProducts(unittest.TestCase):
                 'search_terms=deo axe&json=1&page=' +
                 '3&page_size=20&sort_by=unique_scans',
                 text='{"products":[], "count": 2}')
-            res = openfoodfacts.openbeautyfacts.search_all('deo axe')
+            res = openfoodfacts.beauty_products.search_all('deo axe')
             expected_products_sequence = ["deo axe small", "deo axe", "deo axe big"]
             for i, product in enumerate(res):
                 self.assertEqual(product, expected_products_sequence[i])

--- a/tests/petproducts_test.py
+++ b/tests/petproducts_test.py
@@ -12,11 +12,11 @@ class TestPetProducts(unittest.TestCase):
             mock.get(
                 'https://world.openpetfoodfacts.org/api/v0/product/1223435.json',
                 text='{"name":"product_test"}')
-            res = openfoodfacts.openpetfoodfacts.get_product('1223435')
+            res = openfoodfacts.pet_products.get_product('1223435')
             self.assertEqual(res, {'name': 'product_test'})
 
     def test_get_by_country_and_trace(self):
-        res = openfoodfacts.openpetfoodfacts.get_by_facets({})
+        res = openfoodfacts.pet_products.get_by_facets({})
         self.assertEqual(res, [])
 
         with requests_mock.mock() as mock:
@@ -24,7 +24,7 @@ class TestPetProducts(unittest.TestCase):
                 'https://world.openpetfoodfacts.org/brand/'
                 'Sans%20marque/country/france/1.json',
                 text='{"products":["croquants"]}')
-            res = openfoodfacts.openpetfoodfacts.get_by_facets(
+            res = openfoodfacts.pet_products.get_by_facets(
                     {'brand': 'Sans marque', 'country': 'france'})
             self.assertEqual(res, ["croquants"])
 
@@ -42,7 +42,7 @@ class TestPetProducts(unittest.TestCase):
                 'https://world.openpetfoodfacts.org/brand/'
                 'Sans%20marque/country/france/3.json',
                 text='{"products":[], "count": 0}')
-            res = openfoodfacts.openpetfoodfacts.get_all_by_facets(
+            res = openfoodfacts.pet_products.get_all_by_facets(
                     {'brand': 'Sans marque', 'country': 'france'})
             expected_products_sequence = ["croquants", "croquants small", "croquants big"]
             for i, product in enumerate(res):
@@ -55,14 +55,14 @@ class TestPetProducts(unittest.TestCase):
                 'search_terms=le chat&json=1&page=' +
                 '1&page_size=20&sort_by=unique_scans',
                 text='{"products":["le chat"], "count": 1}')
-            res = openfoodfacts.openpetfoodfacts.search('le chat')
+            res = openfoodfacts.pet_products.search('le chat')
             self.assertEqual(res['products'],  ["le chat"])
             mock.get(
                 'https://world.openpetfoodfacts.org/cgi/search.pl?' +
                 'search_terms=croquants&json=1&page=' +
                 '2&page_size=10&sort_by=unique_scans',
                 text='{"products":["croquants", "croquants big"], "count": 2}')
-            res = openfoodfacts.openpetfoodfacts.search('croquants', page=2, page_size=10)
+            res = openfoodfacts.pet_products.search('croquants', page=2, page_size=10)
             self.assertEqual(res['products'],  ["croquants", "croquants big"])
 
     def test_search_all(self):
@@ -82,7 +82,7 @@ class TestPetProducts(unittest.TestCase):
                 'search_terms=croquants&json=1&page=' +
                 '3&page_size=20&sort_by=unique_scans',
                 text='{"products":[], "count": 2}')
-            res = openfoodfacts.openpetfoodfacts.search_all('croquants')
+            res = openfoodfacts.pet_products.search_all('croquants')
             expected_products_sequence = ["croquants small", "croquants", "croquants big"]
             for i, product in enumerate(res):
                 self.assertEqual(product, expected_products_sequence[i])


### PR DESCRIPTION
This PR adds `pet_products` and` beauty_products` aliases. I think it's more consistent than using `openbeautyfacts` and `openpetfoodfacts`, anyway they are still supported for backward compatibility.
