### PR TITLE
fix: Automate PyPI workflow 

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,11 +2,8 @@ name: Publish PyPI Package
 
 on:
   # Triggers the workflow on a new release
-  push:
-    branches: [actions-dev]
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  release:
+    types: [created]
 
 jobs:
   deploy:
@@ -23,13 +20,12 @@ jobs:
         rm -rf dist build *.egg-info
         python3 -m pip install --upgrade pip
         python3 -m pip install setuptools wheel twine
-    - name: Build dist
+    - name: Build package
       run: |
         python3 setup.py sdist bdist_wheel 
-    - name: Publish package to testPyPI
+    - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_TOKEN }}
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,8 +2,8 @@ name: Publish PyPI Package
 
 on:
   # Triggers the workflow on a new release
-  release:
-    types: [created]
+  push:
+    branches: [actions-dev]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         rm -rf dist build *.egg-info
         python3 -m pip install --upgrade pip
-        python3 -m pip install setuptools wheel twine
+        pip install twine
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,8 +1,12 @@
 name: Publish PyPI Package
 
 on:
+  # Triggers the workflow on a new release
   release:
     types: [created]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -17,12 +21,13 @@ jobs:
     - name: Install dependencies
       run: |
         rm -rf dist build *.egg-info
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        python3 -m pip install --upgrade pip
+        python3 -m pip install setuptools wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+        TWINE_REPOSITORY: testpypi
       run: |
-        python setup.py sdist bdist_wheel
-        sudo python -m twine upload --non-interactive dist/*  
+        python3 setup.py sdist bdist_wheel
+        sudo python3 -m twine upload --non-interactive dist/*  

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python3 setup.py sdist bdist_wheel 
     - name: Publish package to testPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1.5.0
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,12 +22,14 @@ jobs:
       run: |
         rm -rf dist build *.egg-info
         python3 -m pip install --upgrade pip
-        pip install twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-        TWINE_REPOSITORY: testpypi
+        python3 -m pip install setuptools wheel twine
+    - name: Build dist
       run: |
-        python3 setup.py sdist bdist_wheel
-        sudo python3 -m twine upload --non-interactive dist/*  
+        python3 setup.py sdist bdist_wheel 
+    - name: Publish package to testPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1.5.0
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+


### PR DESCRIPTION
**Related issues**
- Fixes #75 

**Problem**
- Twine not found during ["Publish PyPI package"](https://github.com/openfoodfacts/openfoodfacts-python/runs/5869073018?check_suite_focus=true) run.

**Solution**
- Used the github action [pypi-publish](https://github.com/marketplace/actions/pypi-publish) to automate PyPI publish.
- Workflow succeded in fork repo using testPyPI API token.