### PR TITLE
fix: Dependabot error during CodeQL workflow + fix: Disable labeler on forks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,6 @@
 name: "Code scanning - action"
 
 on:
-  push:
   pull_request:
   schedule:
     - cron: '0 9 * * 1'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -18,5 +18,6 @@ jobs:
 
     steps:
     - uses: actions/labeler@v3.0.2
+      if: github.event.pull_request.head.repo.full_name == github.repository
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**Problem**

- In PR #91, there is an issue with the [CodeQL workflow](https://github.com/openfoodfacts/openfoodfacts-python/runs/5972765591?check_suite_focus=true#step:4:51). The error is shown below.

> Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.

- The Labeler workflow gives the following [error](https://github.com/openfoodfacts/openfoodfacts-python/runs/5977084335?check_suite_focus=true#step:2:6) for a forked repo:
> Error: HttpError: Resource not accessible by integration
Error: Resource not accessible by integration

**Solution**
- Removed "push:" from CodeQL workflow as Dependabot branches require write access.
- Disable Labeller if the current repo is a forked repo. (Labeller doesn't work for forked repos due to a permissions issue)