### PR TITLE
build: Changed branch for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
   on:
     push:
       branches:
-        - master
+        - develop
   name: release-please
   jobs:
     release-please:


### PR DESCRIPTION
### Description
- Wrong name of master branch is mentioned in the release-please GitHub Action.

### Solution
- Changed "master" to "develop"

### Related issue(s)
- Fixes #97 