### PR TITLE
feat: add PEP 561 compliance (typing in installed package)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.txt
+global-include *.typed


### PR DESCRIPTION
## Description
Right now for packages which use `openfoodfacts` python package `mypy` complains about missing typing:
```
app/tasks.py:4: error: Skipping analyzing "openfoodfacts": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

## Solution

In order for typing to work we need to mark package with `py.typed` file to comply with PEP 561 and let `mypy` and other tools know that typing should work with that package.
See https://mypy.readthedocs.io/en/stable/installed_packages.html#using-installed-packages-with-mypy-pep-561
