### PR TITLE
fix: fix Flavor.opf domain

### DIFF
--- a/openfoodfacts/types.py
+++ b/openfoodfacts/types.py
@@ -40,7 +40,7 @@ class Flavor(str, enum.Enum):
         elif self == self.opff:
             return "openpetfoodfacts"
         elif self == self.opf:
-            return "openproductfacts"
+            return "openproductsfacts"
         else:
             # Open Food Facts Pro
             return "pro.openfoodfacts"


### PR DESCRIPTION
## Description

There was a typo in the `Flavor.opf` domain (missing `s`)
- before : `openproductfacts`
- after : `openproductsfacts`