### PR TITLE
feat: allow fetching other datasets (obf, opff, opf)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,10 +26,9 @@ All parameters are optional with the exception of user_agent, but here is a desc
 
 - `username` and `password` are used to provide authentication (required for write requests)
 - `country` is used to specify the country, which is used by the API to return product specific to the country or to infer which language to use by default. `world` (all products) is the default value
-- `flavor`: the Open*Facts project you want to interact with: `off` (Open Food Facts, default), `obf` (Open Beauty Facts),...
+- `flavor`: the Open*Facts project you want to interact with: `off` (Open Food Facts, default), `obf` (Open Beauty Facts), `opff` (Open Pet Food Facts), `opf` (Open Products Facts)
 - `version`: API version (v2 is the default)
 - `environment`: either `org` for production environment (openfoodfacts.org) or `net` for staging (openfoodfacts.net)
-
 
 *Get information about a product*
 
@@ -57,24 +56,31 @@ want to update. Example:
 
 ## Using the dataset
 
-If you're planning to perform data analysis on Open Food Facts, the easiest way is to download and use the Open Food Facts dataset dump.
-Fortunately it can be done really easily using the SDK:
+If you're planning to perform data analysis on Open Food Facts, the easiest way is to download and use the Open Food Facts dataset dump. Fortunately it can be done really easily using the SDK:
 
 ```python
 from openfoodfacts import ProductDataset
 
-dataset = ProductDataset("csv")
+dataset = ProductDataset(dataset_type="csv")
 
 for product in dataset:
     print(product["product_name"])
 ```
 
-With `dataset = ProductDataset("csv")`, we automatically download (and cache) the dataset. We can then iterate over it to get information about products.
+With `dataset = ProductDataset(dataset_type="csv")`, we automatically download (and cache) the food dataset. We can then iterate over it to get information about products.
 
-Two dataset types are available `csv` and `jsonl`. The `jsonl` dataset contains all the Open Food Facts database information but takes much more storage (>5 GB), while the `csv` dataset is much ligher (~700 MB) but only contains the most important fields.
+Two dataset types are available `csv` and `jsonl`. The `jsonl` dataset contains all the Open Food Facts database information but takes much more storage (>5 GB), while the `csv` dataset is much ligher (~800 MB) but only contains the most important fields. The `jsonl` dataset type is used by default.
 
-The `jsonl` dataset type is used by default.
+You can also use `ProductDataset` to fetch other non-food datasets:
 
+```python
+from openfoodfacts import ProductDataset
+
+dataset = ProductDataset(dataset_type="csv")
+
+for product in dataset:
+    print(product["product_name"])
+```
 
 ## Taxonomies
 


### PR DESCRIPTION
## Description

The current `ProductDataset` implementation only allows to fetch the OFF (food) data

## Solution

- extend `ProductDataset` to allow fetching other datasets: OBF, OPFF, OPF
- update documentation

## Related issue(s)

- Fixes #220 