### PR TITLE
fix: normalize path separators + add support for downloading obsolete product dump

### DIFF
--- a/openfoodfacts/dataset.py
+++ b/openfoodfacts/dataset.py
@@ -24,6 +24,7 @@ DATASET_FILE_NAMES = {
     Flavor.off: {
         DatasetType.jsonl: "openfoodfacts-products.jsonl.gz",
         DatasetType.csv: "en.openfoodfacts.org.products.csv.gz",
+        DatasetType.obsolete: "openfoodfacts-products_obsolete.jsonl.gz",
     },
     Flavor.obf: {
         DatasetType.jsonl: "openbeautyfacts-products.jsonl.gz",

--- a/openfoodfacts/images.py
+++ b/openfoodfacts/images.py
@@ -192,7 +192,7 @@ def extract_source_from_url(url: str) -> str:
     if url_path.endswith(".json"):
         url_path = str(Path(url_path).with_suffix(".jpg"))
 
-    return url_path
+    return url_path.replace("\\", "/")
 
 
 def download_image(

--- a/openfoodfacts/types.py
+++ b/openfoodfacts/types.py
@@ -870,6 +870,7 @@ class APIConfig(BaseModel):
 class DatasetType(str, enum.Enum):
     csv = "csv"
     jsonl = "jsonl"
+    obsolete = "obsolete"
 
 
 class TaxonomyType(str, enum.Enum):


### PR DESCRIPTION
This PR addresses the issue where the extract_source_from_url function returns paths with backslashes on Windows, causing test failures. The function is updated to normalize path separators to always use Unix-like separators.

## Description

The `extract_source_from_url` function was returning paths with backslashes on Windows, which caused test failures due to path separator differences.

## Solution

- Updated the `extract_source_from_url` function to replace backslashes with forward slashes, ensuring that the function always returns paths with Unix-like separators.

## Related issue(s)

- Fixes #[ISSUE NUMBER]