### PR TITLE
fix: correct path separator issue in extract_source_from_url function for Windows compatibility

### DIFF
--- a/openfoodfacts/images.py
+++ b/openfoodfacts/images.py
@@ -192,6 +192,7 @@ def extract_source_from_url(url: str) -> str:
     if url_path.endswith(".json"):
         url_path = str(Path(url_path).with_suffix(".jpg"))
 
+    # normalize windows path to unix path
     return url_path.replace("\\", "/")
 
 

--- a/openfoodfacts/images.py
+++ b/openfoodfacts/images.py
@@ -192,7 +192,7 @@ def extract_source_from_url(url: str) -> str:
     if url_path.endswith(".json"):
         url_path = str(Path(url_path).with_suffix(".jpg"))
 
-    return url_path
+    return url_path.replace("\\", "/")
 
 
 def download_image(


### PR DESCRIPTION
## Description

The `extract_source_from_url` function was returning paths with backslashes on Windows, which caused test failures due to path separator differences.

## Solution

Updated the `extract_source_from_url` function to replace backslashes with forward slashes, ensuring that the function always returns paths with Unix-like separators.

## Related issue(s)

- Not applicable