### PR TITLE
feat: add support for downloading obsolete product dump in ProductDataset

### DIFF
--- a/openfoodfacts/dataset.py
+++ b/openfoodfacts/dataset.py
@@ -24,7 +24,6 @@ DATASET_FILE_NAMES = {
     Flavor.off: {
         DatasetType.jsonl: "openfoodfacts-products.jsonl.gz",
         DatasetType.csv: "en.openfoodfacts.org.products.csv.gz",
-        DatasetType.obsolete: "openfoodfacts-products_obsolete.jsonl.gz",
     },
     Flavor.obf: {
         DatasetType.jsonl: "openbeautyfacts-products.jsonl.gz",
@@ -47,6 +46,7 @@ def get_dataset(
     force_download: bool = False,
     download_newer: bool = False,
     cache_dir: Optional[Path] = None,
+    obsolete: bool = False,
 ) -> Path:
     """Download (and cache) Open Food Facts dataset.
 
@@ -61,10 +61,13 @@ def get_dataset(
         version is available (based on file Etag)
     :param cache_dir: the cache directory to use, defaults to
         ~/.cache/openfoodfacts/taxonomy
+    :param obsolete: if True, download the obsolete dataset, defaults to False
     :return: the path of the dataset
     """
     cache_dir = DEFAULT_CACHE_DIR if cache_dir is None else cache_dir
     file_name = DATASET_FILE_NAMES[flavor][dataset_type]
+    if obsolete:
+        file_name = file_name.replace(".jsonl.gz", "_obsolete.jsonl.gz")
     dataset_path = cache_dir / file_name
     url = f"{URLBuilder.static(flavor, Environment.org)}/data/{file_name}"
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -83,6 +86,7 @@ class ProductDataset:
         flavor: Flavor = Flavor.off,
         dataset_type: DatasetType = DatasetType.jsonl,
         dataset_path: Optional[Path] = None,
+        obsolete: bool = False,
         **kwargs,
     ):
         """A product dataset.
@@ -102,6 +106,7 @@ class ProductDataset:
             to DatasetType.jsonl. This parameter is ignored if dataset_path is
             provided.
         :param dataset_path: the path of the dataset, defaults to None.
+        :param obsolete: if True, download the obsolete dataset, defaults to False.
         :param kwargs: additional arguments passed to `get_dataset` when
             downloading the dataset
         """
@@ -119,7 +124,7 @@ class ProductDataset:
             else:
                 raise ValueError(f"Unknown dataset type: {full_suffix}")
         else:
-            self.dataset_path = get_dataset(flavor, dataset_type, **kwargs)
+            self.dataset_path = get_dataset(flavor, dataset_type, obsolete=obsolete, **kwargs)
 
     def __iter__(self):
         if self.dataset_type is DatasetType.jsonl:

--- a/openfoodfacts/dataset.py
+++ b/openfoodfacts/dataset.py
@@ -24,6 +24,7 @@ DATASET_FILE_NAMES = {
     Flavor.off: {
         DatasetType.jsonl: "openfoodfacts-products.jsonl.gz",
         DatasetType.csv: "en.openfoodfacts.org.products.csv.gz",
+        DatasetType.obsolete: "openfoodfacts-products_obsolete.jsonl.gz",
     },
     Flavor.obf: {
         DatasetType.jsonl: "openbeautyfacts-products.jsonl.gz",

--- a/openfoodfacts/types.py
+++ b/openfoodfacts/types.py
@@ -870,7 +870,6 @@ class APIConfig(BaseModel):
 class DatasetType(str, enum.Enum):
     csv = "csv"
     jsonl = "jsonl"
-    obsolete = "obsolete"
 
 
 class TaxonomyType(str, enum.Enum):

--- a/openfoodfacts/types.py
+++ b/openfoodfacts/types.py
@@ -870,6 +870,7 @@ class APIConfig(BaseModel):
 class DatasetType(str, enum.Enum):
     csv = "csv"
     jsonl = "jsonl"
+    obsolete = "obsolete"
 
 
 class TaxonomyType(str, enum.Enum):


### PR DESCRIPTION
## Description

Currently, the ProductDataset class does not support downloading the obsolete product dump. This feature allows users to access the obsolete product data from Open Food Facts.

## Solution

Added support for downloading the obsolete product dump in ProductDataset. Introduced a new DatasetType.obsolete and updated relevant functions to handle this dataset.

## Related issue(s)

- Fixes #278