### PR TITLE
docs: add missing changelog for #223

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 
 ### Features
 
+* allow fetching other datasets (obf, opff, opf) ([#223](https://github.com/openfoodfacts/openfoodfacts-python/pull/223))
 * add download_image function ([#243](https://github.com/openfoodfacts/openfoodfacts-python/issues/243)) ([265f10b](https://github.com/openfoodfacts/openfoodfacts-python/commit/265f10bfa9047c48874255fbc66d9bab32fa61c5))
 
 ## [0.3.0](https://github.com/openfoodfacts/openfoodfacts-python/compare/v0.2.1...v0.3.0) (2024-04-18)


### PR DESCRIPTION
## Description

Following #223 it did not appear in the Changelog
https://github.com/openfoodfacts/openfoodfacts-python/releases/tag/v0.4.0

Also added the line in the corresponding release