### PR TITLE
fix!: fix should_download_file function

### DIFF
--- a/openfoodfacts/dataset.py
+++ b/openfoodfacts/dataset.py
@@ -58,7 +58,9 @@ def get_dataset(
     :param force_download: if True, (re)download the dataset even if it was
         cached, defaults to False
     :param download_newer: if True, download the dataset if a more recent
-        version is available (based on file Etag)
+        version compared to the cached version is available (based on file
+        Etag). This parameter if ignored if force_download is True, defaults
+        to False.
     :param cache_dir: the cache directory to use, defaults to
         ~/.cache/openfoodfacts/taxonomy
     :param obsolete: if True, download the obsolete dataset, defaults to False
@@ -106,7 +108,8 @@ class ProductDataset:
             to DatasetType.jsonl. This parameter is ignored if dataset_path is
             provided.
         :param dataset_path: the path of the dataset, defaults to None.
-        :param obsolete: if True, download the obsolete dataset, defaults to False.
+        :param obsolete: if True, download the obsolete dataset, defaults to
+            False.
         :param kwargs: additional arguments passed to `get_dataset` when
             downloading the dataset
         """
@@ -124,7 +127,9 @@ class ProductDataset:
             else:
                 raise ValueError(f"Unknown dataset type: {full_suffix}")
         else:
-            self.dataset_path = get_dataset(flavor, dataset_type, obsolete=obsolete, **kwargs)
+            self.dataset_path = get_dataset(
+                flavor, dataset_type, obsolete=obsolete, **kwargs
+            )
 
     def __iter__(self):
         if self.dataset_type is DatasetType.jsonl:

--- a/openfoodfacts/taxonomy.py
+++ b/openfoodfacts/taxonomy.py
@@ -384,7 +384,9 @@ def get_taxonomy(
     :param force_download: if True, (re)download the taxonomy even if it was
         cached, defaults to False
     :param download_newer: if True, download the taxonomy if a more recent
-        version is available (based on file Etag)
+        version compared to the cached version is available (based on file
+        Etag). This parameter if ignored if force_download is True, defaults
+        to False.
     :param cache_dir: the cache directory to use, defaults to
         ~/.cache/openfoodfacts/taxonomy
     :return: a Taxonomy

--- a/openfoodfacts/utils.py
+++ b/openfoodfacts/utils.py
@@ -242,28 +242,31 @@ def fetch_etag(url: str) -> str:
 def should_download_file(
     url: str, filepath: Path, force_download: bool, download_newer: bool
 ) -> bool:
-    """Return True if the file located at `url` should be downloaded again
-    based on file Etag.
+    """Return True if the file located at `url` should be downloaded again.
 
     :param url: the file URL
     :param filepath: the file cached location
     :param force_download: if True, (re)download the file even if it was
         cached, defaults to False
-    :param download_newer: if True, download the file if a more recent
-        version is available (based on file Etag)
+    :param download_newer: if True, download the dataset if a more recent
+        version compared to the cached version is available (based on file
+        Etag). This parameter if ignored if force_download is True, defaults
+        to False.
     :return: True if the file should be downloaded again, False otherwise
     """
     if filepath.is_file():
-        if not force_download:
-            return False
+        if force_download:
+            # Always download the file if force_download is True
+            return True
 
         if download_newer:
+            # Check if the file is up to date
             cached_etag = get_file_etag(filepath)
             current_etag = fetch_etag(url)
-
-            if cached_etag == current_etag:
-                # The file is up to date, return cached file path
-                return False
+            return cached_etag != current_etag
+        else:
+            # The file exists, no need to download it again
+            return False
 
     return True
 


### PR DESCRIPTION
The implementation of the should_download_file function was buggy, as we didn't always force the download of the file when `force_download` was True and `download_newer` was True as well.