### PR TITLE
fix(metadata): set license to "MIT" (as in LICENSE file)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "openfoodfacts"
 version = "2.5.0"
 description = "Official Python SDK of Open Food Facts"
 authors = ["The Open Food Facts team"]
-license = "Apache 2.0"
+license = "MIT"
 readme = "README.md"
 
 [tool.mypy]


### PR DESCRIPTION
## Description

no idea why 'Apache 2.0' was introduced in https://github.com/openfoodfacts/openfoodfacts-python/commit/a7c11697b8d2bb6aa48985b25e04d6c666af384c but MIT seems to be correct because it's mentioned both in the README and the LICENSE file itself.

## Solution

- I fixed the metadata in the `pyproject.toml` file, so that they match the actual license

## Related issue(s)

- Didn't open a bug for this (yet).