### PR TITLE
fix(metadata): add project repository URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Official Python SDK of Open Food Facts"
 authors = ["The Open Food Facts team"]
 license = "Apache 2.0"
 readme = "README.md"
+repository = "https://github.com/openfoodfacts/openfoodfacts-python"
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
so that it's also displayed e.g. on pypi
docs: https://python-poetry.org/docs/pyproject/#repository

## Description

If you visit the [pypi project page](https://pypi.org/project/openfoodfacts/2.5.0/), there's no link in  the sidebar that points to this repository. The PR fixes that. 

## Solution

- Added repository URL as described in poetry docs.

## Related issue(s)

- Didn't open an issue for that (yet).