### PR TITLE
docs(api.py): Add note about 10,000 results API limitation

### DIFF
--- a/openfoodfacts/api.py
+++ b/openfoodfacts/api.py
@@ -2,6 +2,10 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import requests
+"""
+NOTE: The Open Food Facts API limits queries to 10,000 results by default.
+This limitation may affect large data requests and should be considered when querying large datasets.
+"""
 
 from .types import APIConfig, APIVersion, Country, Environment, Facet, Flavor, JSONType
 from .utils import URLBuilder, http_session


### PR DESCRIPTION
## Summary

This pull request adds a clarifying note at the top of the `api.py` file to highlight the Open Food Facts API's 10,000 results limitation. This helps developers be aware of potential query issues when dealing with large datasets.

## Why this is useful

While working on the Python SDK as part of my exploration for Google Summer of Code 2025, I noticed that the API has an undocumented limit of 10,000 results, which could confuse new developers or lead to unexpected behavior in large queries. This small documentation update adds clarity and helps prevent confusion.

## Context

This is part of my first-time contributions to the Open Food Facts project under the GSoC 2025 exploration. I plan to work on improving SDK usability and developer experience.

---

Let me know if anything else needs to be added or adjusted :)
