### PR TITLE
docs: add example usage for add_image method

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,11 @@
+from openfoodfacts import API
+
+api = API(user_id="tejaswibks", password="your_password")
+
+result = api.add_image(
+    barcode="1234567890123",
+    imagefield="front",
+    imgpath="path/to/your/image.jpg"
+)
+
+print(result.status)

--- a/openfoodfacts/api.py
+++ b/openfoodfacts/api.py
@@ -2,6 +2,10 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import requests
+"""
+NOTE: The Open Food Facts API limits queries to 10,000 results by default.
+This limitation may affect large data requests and should be considered when querying large datasets.
+"""
 
 from .types import APIConfig, APIVersion, Country, Environment, Facet, Flavor, JSONType
 from .utils import URLBuilder, http_session


### PR DESCRIPTION
📄 Added example documentation for the `add_image()` method in the Open Food Facts Python SDK.

The example includes:
- How to authenticate using `API`
- Parameters for barcode, imagefield, and imgpath
- Clarifies usage with placeholder values

This will help new contributors and developers understand how to use this method effectively. 😄

Fixes #69  ← (If you commented on an issue earlier, add that number here)
