### PR TITLE
fix: add new function to convert images to old schema

### DIFF
--- a/openfoodfacts/images.py
+++ b/openfoodfacts/images.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 import requests
 
-from openfoodfacts.types import Environment, Flavor
+from openfoodfacts.types import Environment, Flavor, JSONType
 from openfoodfacts.utils import ImageDownloadItem, URLBuilder, get_image_from_url
 
 logger = logging.getLogger(__name__)
@@ -254,3 +254,99 @@ def download_image(
         session=session,
         return_struct=return_struct,
     )
+
+
+def convert_to_legacy_schema(images: JSONType) -> JSONType:
+    """Convert the images dictionary to the legacy schema.
+
+    We've improved the schema of the `images` field, but the new
+    schema is not compatible with the legacy schema. This function
+    converts the new schema to the legacy schema.
+
+    It can be used while migrating the existing Python codebase to the
+    new schema.
+
+    The new `images` schema is the following:
+
+    - the `images` field contains the uploaded images under the `uploaded`
+        key and the selected images under the `selected` key
+    - `uploaded` contains the images that are uploaded, and maps the
+        image ID to the detail about the image:
+        - `uploaded_t`: the upload timestamp
+        - `uploader`: the username of the uploader
+        - `sizes`: dictionary mapping image size (`100`, `200`, `400`, `full`)
+            to the information about each resized image:
+            - `h`: the height of the image
+            - `w`: the width of the image
+            - `url`: the URL of the image
+    - `selected` contains the images that are selected, and maps the
+        image key (`nutrition`, `ingredients`, `packaging`, or `front`) to
+        a dictionary mapping the language to the selected image details.
+        The selected image details are the following fields:
+        - `imgid`: the image ID
+        - `rev`: the revision ID
+        - `sizes`: dictionary mapping image size (`100`, `200`, `400`, `full`)
+            to the information about each resized image:
+            - `h`: the height of the image
+            - `w`: the width of the image
+            - `url`: the URL of the image
+        - `generation`: information about how to generate the selected image
+            from the uploaded image:
+            - `geometry`
+            - `x1`, `y1`, `x2`, `y2`: the coordinates of the crop
+            - `angle`: the rotation angle of the selected image
+            - `coordinates_image_size`: 400 or "full", indicates if the
+                geometry coordinates are relative to the full image, or to a
+                resized version (max width and max height=400)
+            - `normalize`: indicates if colors should be normalized
+            - `white_magic`: indicates if the background is white and should
+                be removed (e.g. photo on a white sheet of paper)
+
+    See https://github.com/openfoodfacts/openfoodfacts-server/pull/11818
+    for more details.
+    """
+
+    if not is_new_image_schema(images):
+        return images
+
+    images_with_legacy_schema = {}
+
+    for image_id, image_data in images["uploaded"].items():
+        images_with_legacy_schema[image_id] = {
+            "sizes": {
+                # remove URL field
+                size: {k: v for k, v in image_size_data.items() if k != "url"}
+                for size, image_size_data in image_data["sizes"].items()
+            },
+            "uploaded_t": image_data["uploaded_t"],
+            "uploader": image_data["uploader"],
+        }
+
+    for selected_key, image_by_lang in images["selected"].items():
+        for lang, image_data in image_by_lang.items():
+            new_image_data = {
+                "imgid": image_data["imgid"],
+                "rev": image_data["rev"],
+                "sizes": {
+                    # remove URL field
+                    size: {k: v for k, v in image_size_data.items() if k != "url"}
+                    for size, image_size_data in image_data["sizes"].items()
+                },
+                **image_data["generation"],
+            }
+            images_with_legacy_schema[f"{selected_key}_{lang}"] = new_image_data
+
+    return images_with_legacy_schema
+
+
+def is_new_image_schema(images_data: JSONType) -> bool:
+    """Return True if the `images` dictionary follows the new Product Opener
+    images schema.
+
+    See https://github.com/openfoodfacts/openfoodfacts-server/pull/11818 for
+    more information about this new schema.
+    """
+    if not images_data:
+        return False
+
+    return "selected" in images_data or "uploaded" in images_data

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -3,6 +3,7 @@ from typing import Optional
 import pytest
 
 from openfoodfacts.images import (
+    convert_to_legacy_schema,
     extract_barcode_from_url,
     extract_source_from_url,
     generate_image_url,
@@ -156,3 +157,293 @@ def test_generate_json_ocr_url(code, image_id, flavor, environment, expected):
 )
 def test_extract_barcode_from_url(url, expected):
     assert extract_barcode_from_url(url) == expected
+
+
+IMAGES_WITH_LEGACY_SCHEMA = {
+    "1": {
+        "sizes": {
+            "100": {"h": 100, "w": 56},
+            "400": {"h": 400, "w": 225},
+            "full": {"h": 3555, "w": 2000},
+        },
+        "uploaded_t": "1490702616",
+        "uploader": "user1",
+    },
+    "2": {
+        "sizes": {
+            "100": {"h": 100, "w": 56},
+            "400": {"h": 400, "w": 225},
+            "full": {"h": 3555, "w": 2000},
+        },
+        "uploaded_t": "1490702690",
+        "uploader": "user2",
+    },
+    "3": {
+        "sizes": {
+            "100": {"h": 100, "w": 56},
+            "400": {"h": 400, "w": 225},
+            "full": {"h": 3555, "w": 2000},
+        },
+        "uploaded_t": "1490702705",
+        "uploader": "user2",
+    },
+    "front_fr": {
+        "angle": None,
+        "geometry": "0x0-0-0",
+        "imgid": "3",
+        "normalize": "0",
+        "rev": "27",
+        "sizes": {
+            "100": {"h": 100, "w": 75},
+            "200": {"h": 200, "w": 150},
+            "400": {"h": 400, "w": 300},
+            "full": {"h": 1200, "w": 901},
+        },
+        "white_magic": "0",
+        "x1": None,
+        "x2": None,
+        "y1": None,
+        "y2": None,
+    },
+    "ingredients_fr": {
+        "angle": None,
+        "geometry": "0x0-0-0",
+        "imgid": "1",
+        "normalize": "0",
+        "ocr": 1,
+        "orientation": "0",
+        "rev": "29",
+        "sizes": {
+            "100": {"h": 40, "w": 100},
+            "200": {"h": 81, "w": 200},
+            "400": {"h": 162, "w": 400},
+            "full": {"h": 1200, "w": 2972},
+        },
+        "white_magic": "0",
+        "x1": None,
+        "x2": None,
+        "y1": None,
+        "y2": None,
+    },
+    "nutrition_fr": {
+        "angle": None,
+        "geometry": "0x0-0-0",
+        "imgid": "2",
+        "normalize": "0",
+        "ocr": 1,
+        "orientation": "0",
+        "rev": "18",
+        "sizes": {
+            "100": {"h": 53, "w": 100},
+            "200": {"h": 107, "w": 200},
+            "400": {"h": 213, "w": 400},
+            "full": {"h": 1093, "w": 2050},
+        },
+        "white_magic": "0",
+        "x1": None,
+        "x2": None,
+        "y1": None,
+        "y2": None,
+    },
+}
+
+
+IMAGES_WITH_NEW_SCHEMA = IMAGES = {
+    "uploaded": {
+        "1": {
+            "sizes": {
+                "100": {
+                    "h": 100,
+                    "w": 56,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/1.100.jpg",
+                },
+                "400": {
+                    "h": 400,
+                    "w": 225,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/1.400.jpg",
+                },
+                "full": {
+                    "h": 3555,
+                    "w": 2000,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/1.jpg",
+                },
+            },
+            "uploaded_t": "1490702616",
+            "uploader": "user1",
+        },
+        "2": {
+            "sizes": {
+                "100": {
+                    "h": 100,
+                    "w": 56,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/2.100.jpg",
+                },
+                "400": {
+                    "h": 400,
+                    "w": 225,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/2.400.jpg",
+                },
+                "full": {
+                    "h": 3555,
+                    "w": 2000,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/2.jpg",
+                },
+            },
+            "uploaded_t": "1490702690",
+            "uploader": "user2",
+        },
+        "3": {
+            "sizes": {
+                "100": {
+                    "h": 100,
+                    "w": 56,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/3.100.jpg",
+                },
+                "400": {
+                    "h": 400,
+                    "w": 225,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/3.400.jpg",
+                },
+                "full": {
+                    "h": 3555,
+                    "w": 2000,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/3.jpg",
+                },
+            },
+            "uploaded_t": "1490702705",
+            "uploader": "user2",
+        },
+    },
+    "selected": {
+        "front": {
+            "fr": {
+                "imgid": "3",
+                "rev": "27",
+                "sizes": {
+                    "100": {
+                        "h": 100,
+                        "w": 75,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/front_fr.27.100.jpg",
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/front_fr.27.200.jpg",
+                    },
+                    "400": {
+                        "h": 400,
+                        "w": 300,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/front_fr.27.400.jpg",
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 901,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/front_fr.27.full.jpg",
+                    },
+                },
+                "generation": {
+                    "white_magic": "0",
+                    "x1": None,
+                    "x2": None,
+                    "y1": None,
+                    "y2": None,
+                    "normalize": "0",
+                    "angle": None,
+                    "geometry": "0x0-0-0",
+                },
+            },
+        },
+        "nutrition": {
+            "fr": {
+                "imgid": "2",
+                "rev": "18",
+                "sizes": {
+                    "100": {
+                        "h": 53,
+                        "w": 100,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/nutrition_fr.18.100.jpg",
+                    },
+                    "200": {
+                        "h": 107,
+                        "w": 200,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/nutrition_fr.18.200.jpg",
+                    },
+                    "400": {
+                        "h": 213,
+                        "w": 400,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/nutrition_fr.18.400.jpg",
+                    },
+                    "full": {
+                        "h": 1093,
+                        "w": 2050,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/nutrition_fr.18.full.jpg",
+                    },
+                },
+                "generation": {
+                    "white_magic": "0",
+                    "x1": None,
+                    "x2": None,
+                    "y1": None,
+                    "y2": None,
+                    "normalize": "0",
+                    "ocr": 1,
+                    "orientation": "0",
+                    "angle": None,
+                    "geometry": "0x0-0-0",
+                },
+            },
+        },
+        "ingredients": {
+            "fr": {
+                "imgid": "1",
+                "rev": "29",
+                "sizes": {
+                    "100": {
+                        "h": 40,
+                        "w": 100,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/ingredients_fr.29.100.jpg",
+                    },
+                    "200": {
+                        "h": 81,
+                        "w": 200,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/ingredients_fr.29.200.jpg",
+                    },
+                    "400": {
+                        "h": 162,
+                        "w": 400,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/ingredients_fr.29.400.jpg",
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 2972,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/ingredients_fr.29.full.jpg",
+                    },
+                },
+                "generation": {
+                    "white_magic": "0",
+                    "x1": None,
+                    "x2": None,
+                    "y1": None,
+                    "y2": None,
+                    "normalize": "0",
+                    "ocr": 1,
+                    "orientation": "0",
+                    "angle": None,
+                    "geometry": "0x0-0-0",
+                },
+            }
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "images,expected_result",
+    [
+        ({}, {}),
+        (IMAGES_WITH_LEGACY_SCHEMA, IMAGES_WITH_LEGACY_SCHEMA),
+        (IMAGES_WITH_NEW_SCHEMA, IMAGES_WITH_LEGACY_SCHEMA),
+    ],
+)
+def test_convert_to_legacy_schema(images, expected_result):
+    assert convert_to_legacy_schema(images) == expected_result


### PR DESCRIPTION
In order to smoothly transition to the new `images` schema (https://github.com/openfoodfacts/openfoodfacts-server/pull/11818), I introduce here a function that can be used in any OFF Python project to convert the new schema to the old one.

It can be used while migrating the existing Python codebase to the new schema.