### PR TITLE
feat: add face annotations support in OCRResult

### DIFF
--- a/openfoodfacts/ocr.py
+++ b/openfoodfacts/ocr.py
@@ -1153,27 +1153,15 @@ class FaceAnnotation:
 
     def __init__(self, data: JSONType):
         self.detection_confidence = data.get("detectionConfidence", 0.0)
-        self.joy_likelihood = SafeSearchAnnotationLikelihood[
-            data.get("joyLikelihood", "UNKNOWN")
-        ]
-        self.sorrow_likelihood = SafeSearchAnnotationLikelihood[
-            data.get("sorrowLikelihood", "UNKNOWN")
-        ]
-        self.anger_likelihood = SafeSearchAnnotationLikelihood[
-            data.get("angerLikelihood", "UNKNOWN")
-        ]
-        self.surprise_likelihood = SafeSearchAnnotationLikelihood[
-            data.get("surpriseLikelihood", "UNKNOWN")
-        ]
-        self.under_exposed_likelihood = SafeSearchAnnotationLikelihood[
+        self.joy_likelihood = Likelihood[data.get("joyLikelihood", "UNKNOWN")]
+        self.sorrow_likelihood = Likelihood[data.get("sorrowLikelihood", "UNKNOWN")]
+        self.anger_likelihood = Likelihood[data.get("angerLikelihood", "UNKNOWN")]
+        self.surprise_likelihood = Likelihood[data.get("surpriseLikelihood", "UNKNOWN")]
+        self.under_exposed_likelihood = Likelihood[
             data.get("underExposedLikelihood", "UNKNOWN")
         ]
-        self.blurred_likelihood = SafeSearchAnnotationLikelihood[
-            data.get("blurredLikelihood", "UNKNOWN")
-        ]
-        self.headwear_likelihood = SafeSearchAnnotationLikelihood[
-            data.get("headwearLikelihood", "UNKNOWN")
-        ]
+        self.blurred_likelihood = Likelihood[data.get("blurredLikelihood", "UNKNOWN")]
+        self.headwear_likelihood = Likelihood[data.get("headwearLikelihood", "UNKNOWN")]
 
 
 class SafeSearchAnnotation:
@@ -1197,6 +1185,16 @@ class SafeSearchAnnotation:
         ]
 
 
+class Likelihood(enum.IntEnum):
+    UNKNOWN = 1
+    VERY_UNLIKELY = 2
+    UNLIKELY = 3
+    POSSIBLE = 4
+    LIKELY = 5
+    VERY_LIKELY = 6
+
+
+# This class should be deleted and replaced by `Likelihood` in the future.
 class SafeSearchAnnotationLikelihood(enum.IntEnum):
     UNKNOWN = 1
     VERY_UNLIKELY = 2

--- a/openfoodfacts/ocr.py
+++ b/openfoodfacts/ocr.py
@@ -109,6 +109,7 @@ class OCRResult:
         "logo_annotations",
         "safe_search_annotation",
         "label_annotations",
+        "face_annotations",
     )
 
     def __init__(self, data: JSONType):
@@ -117,6 +118,7 @@ class OCRResult:
         self.logo_annotations: List[LogoAnnotation] = []
         self.label_annotations: List[LabelAnnotation] = []
         self.safe_search_annotation: Optional[SafeSearchAnnotation] = None
+        self.face_annotations: List[FaceAnnotation] = []
 
         for text_annotation_data in data.get("textAnnotations", []):
             text_annotation = OCRTextAnnotation(text_annotation_data)
@@ -144,6 +146,10 @@ class OCRResult:
             self.safe_search_annotation = SafeSearchAnnotation(
                 data["safeSearchAnnotation"]
             )
+
+        for face_annotation_data in data.get("faceAnnotations", []):
+            face_annotation = FaceAnnotation(face_annotation_data)
+            self.face_annotations.append(face_annotation)
 
     def get_full_text(self) -> str:
         return (
@@ -185,6 +191,9 @@ class OCRResult:
 
     def get_label_annotations(self) -> List["LabelAnnotation"]:
         return self.label_annotations
+
+    def get_face_annotations(self) -> List["FaceAnnotation"]:
+        return self.face_annotations
 
     def get_safe_search_annotation(self):
         return self.safe_search_annotation
@@ -1128,6 +1137,43 @@ class LabelAnnotation:
         self.id = data.get("mid") or None
         self.score = data["score"]
         self.description = data["description"]
+
+
+class FaceAnnotation:
+    __slots__ = (
+        "detection_confidence",
+        "joy_likelihood",
+        "sorrow_likelihood",
+        "anger_likelihood",
+        "surprise_likelihood",
+        "under_exposed_likelihood",
+        "blurred_likelihood",
+        "headwear_likelihood",
+    )
+
+    def __init__(self, data: JSONType):
+        self.detection_confidence = data.get("detectionConfidence", 0.0)
+        self.joy_likelihood = SafeSearchAnnotationLikelihood[
+            data.get("joyLikelihood", "UNKNOWN")
+        ]
+        self.sorrow_likelihood = SafeSearchAnnotationLikelihood[
+            data.get("sorrowLikelihood", "UNKNOWN")
+        ]
+        self.anger_likelihood = SafeSearchAnnotationLikelihood[
+            data.get("angerLikelihood", "UNKNOWN")
+        ]
+        self.surprise_likelihood = SafeSearchAnnotationLikelihood[
+            data.get("surpriseLikelihood", "UNKNOWN")
+        ]
+        self.under_exposed_likelihood = SafeSearchAnnotationLikelihood[
+            data.get("underExposedLikelihood", "UNKNOWN")
+        ]
+        self.blurred_likelihood = SafeSearchAnnotationLikelihood[
+            data.get("blurredLikelihood", "UNKNOWN")
+        ]
+        self.headwear_likelihood = SafeSearchAnnotationLikelihood[
+            data.get("headwearLikelihood", "UNKNOWN")
+        ]
 
 
 class SafeSearchAnnotation:


### PR DESCRIPTION
Add support for parsing face annotations from Google Cloud Vision API responses.

Part of Robotoff PR #[1585](https://github.com/openfoodfacts/robotoff/pull/1585)

Superset of #330.