### PR TITLE
chore: Drop `setup.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ or manually from source:
 
     git clone https://github.com/openfoodfacts/openfoodfacts-python
     cd openfoodfacts-python
-    python setup.py install
+    pip install .  # Note the “.” at the end!
 
 ## Examples
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   number: 0
-  script: python setup.py install
+  script: python -m pip install .
 
 requirements:
   host:
@@ -17,7 +17,7 @@ requirements:
     - python
   run:
     - python
-    - requests >=2.20.0 
+    - requests >=2.20.0
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-import setuptools  # type: ignore
-
-setuptools.setup()


### PR DESCRIPTION
While `setup.py` itself isn’t deprecated,

> `python setup.py` and the use of `setup.py` as a command line tool
> are deprecated.
>
> This means that commands such as [`python setup.py install`]
> **MUST NOT** be run anymore

— https://packaging.python.org/en/latest/discussions/setup-py-deprecated/

Given that our `setup.py` exists solely to run as a command, let’s just drop it and update documentation accordingly.

Fixes https://github.com/openfoodfacts/openfoodfacts-python/issues/324