### PR TITLE
fix: strip leading 0 before splitting barcodes

### DIFF
--- a/openfoodfacts/images.py
+++ b/openfoodfacts/images.py
@@ -42,7 +42,7 @@ def split_barcode(barcode: str) -> List[str]:
         raise ValueError(f"unknown barcode format: {barcode}")
 
     # Pad the barcode with zeros to ensure it has 13 digits
-    barcode = barcode.zfill(13)
+    barcode = barcode.lstrip("0").zfill(13)
     # Split the first 9 digits of the barcode into 3 groups of 3 digits to
     # get the first 3 folder names and use the rest of the barcode as the
     # last folder name

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -62,6 +62,15 @@ def test_get_source_from_url(url: str, output: str):
             Environment.org,
             "https://images.openfoodfacts.org/images/products/541/012/672/6954/1.jpg",
         ),
+        # Test that barcode normalization (stripping leading zeros) works
+        # correctly
+        (
+            "0005410126726954",
+            "1",
+            Flavor.off,
+            Environment.org,
+            "https://images.openfoodfacts.org/images/products/541/012/672/6954/1.jpg",
+        ),
         (
             "990530101113758685",
             "2",


### PR DESCRIPTION
In some cases, the generated image URL was invalid.