### PR TITLE
feat: implement POST /api/v3/product/{barcode}/images route

### DIFF
--- a/openfoodfacts/api.py
+++ b/openfoodfacts/api.py
@@ -1,4 +1,7 @@
+import base64
 import logging
+import warnings
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import requests
@@ -62,6 +65,28 @@ def send_form_urlencoded_post_request(
         cookies=cookies,
     )
     r.raise_for_status()
+    return r
+
+
+def send_json_post_request(
+    url: str, body: JSONType, api_config: APIConfig
+) -> requests.Response:
+    cookies = None
+    if api_config.username and api_config.password:
+        body["user_id"] = api_config.username
+        body["password"] = api_config.password
+    elif api_config.session_cookie:
+        cookies = {
+            "session": api_config.session_cookie,
+        }
+    r = http_session.post(
+        url,
+        json=body,
+        headers={"User-Agent": api_config.user_agent},
+        timeout=api_config.timeout,
+        auth=get_http_auth(api_config.environment),
+        cookies=cookies,
+    )
     return r
 
 
@@ -415,6 +440,106 @@ class ProductResource:
             raise RuntimeError(f"Unable to parse ingredients: {response_data}")
 
         return response_data["product"].get("ingredients", [])
+
+    def upload_image(
+        self,
+        code: str,
+        image_path: Path | str | None = None,
+        image_data_base64: str | None = None,
+        selected: JSONType | None = None,
+    ):
+        """Upload an image for a product, and optionally select this image for
+        some specific field and language (example: `nutrition` image for `es`
+        language).
+
+        This method requires a password to be set in the API configuration.
+        Authentication through a session cookie does not seem to work
+        currently.
+
+        We force here the usage of v3 of the API.
+
+        The image can be provided either as a file path or as a base64-encoded
+        string.
+
+        :param code: the product barcode
+        :param image_path: the path to the image file, defaults to None. One of
+            image_path or image_data_base64 must be provided.
+        :param image_data_base64: the base64-encoded image, defaults to None.
+            One of image_path or image_data_base64 must be provided.
+        :param selected: a dict that describes how to select the image after
+            upload, defaults to None (no selection). Example:
+            {
+                "front": {"fr": {}},
+                "ingredients": {"en": {}},
+            }
+            will select the image as the front image for french language and
+            as the ingredients image for english language.
+
+        :return: the API response (a requests.Response object)
+        :raises ValueError: if no password or session cookie is provided, or if
+            both image_path and image_data_base64 are None.
+        """
+        if self.api_config.version != APIVersion.v3:
+            warnings.warn(
+                "image upload is only available in v3 of the API (here: %s), forcing use of v3"
+                % self.api_config.version,
+            )
+
+        if (self.api_config.username is None or self.api_config.password is None) and (
+            self.api_config.session_cookie is None
+        ):
+            raise ValueError(
+                "a password or a session cookie is required to upload an image"
+            )
+
+        if not code.isdigit():
+            raise ValueError("code must be a numeric string")
+
+        if image_path is None and image_data_base64 is None:
+            raise ValueError("one of image_path or image_data_base64 must be provided")
+
+        if image_path is not None and image_data_base64 is not None:
+            raise ValueError(
+                "only one of image_path or image_data_base64 must be provided"
+            )
+
+        if image_data_base64 is None and image_path is not None:
+            with Path(image_path).open("rb") as f:
+                image_data_base64 = base64.b64encode(f.read()).decode("utf-8")
+
+        if selected:
+            for key in selected:
+                if key not in ("front", "ingredients", "nutrition", "packaging"):
+                    raise ValueError(
+                        f"invalid image field name in selected: {key} "
+                        "(must be one of front, ingredients, nutrition, packaging)"
+                    )
+                lang_info = selected[key]
+                if not isinstance(lang_info, dict):
+                    raise ValueError(
+                        f"selected[{key}] must be a dict with a language code, "
+                        f"got {type(lang_info)}"
+                    )
+
+                for lang_code, value in lang_info.items():
+                    if not isinstance(lang_code, str) or len(lang_code) != 2:
+                        raise ValueError(
+                            f"invalid language code in selected[{key}]: {lang_code}"
+                        )
+                    if not isinstance(value, dict):
+                        raise ValueError(
+                            f"selected[{key}][{lang_code}] must be a dict, got {type(value)}"
+                        )
+
+        # copy the config but force v3 of the API
+        api_config = self.api_config.model_copy(update={"version": APIVersion.v3})
+        url = f"{self.base_url}/api/v3/product/{code}/images"
+        data: JSONType = {"image_data_base64": image_data_base64}
+
+        if selected:
+            data["selected"] = selected
+
+        return send_json_post_request(url, data, api_config)
 
 
 class API:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,6 +1,5 @@
 import json
 import re
-import unittest
 
 import pytest
 import requests_mock
@@ -10,7 +9,7 @@ import openfoodfacts
 TEST_USER_AGENT = "test_off_python"
 
 
-class TestProducts(unittest.TestCase):
+class TestProducts:
     def test_get_product(self):
         api = openfoodfacts.API(user_agent=TEST_USER_AGENT, version="v2")
         code = "1223435"
@@ -25,7 +24,7 @@ class TestProducts(unittest.TestCase):
                 text=json.dumps(response_data),
             )
             res = api.product.get(code)
-            self.assertEqual(res, response_data["product"])
+            assert res == response_data["product"]
 
     def test_get_product_missing(self):
         api = openfoodfacts.API(user_agent=TEST_USER_AGENT, version="v2")
@@ -41,7 +40,7 @@ class TestProducts(unittest.TestCase):
                 status_code=404,
             )
             res = api.product.get(code)
-            self.assertEqual(res, None)
+            assert res is None
 
     def test_get_product_with_fields(self):
         api = openfoodfacts.API(user_agent=TEST_USER_AGENT, version="v2")
@@ -57,8 +56,8 @@ class TestProducts(unittest.TestCase):
                 text=json.dumps(response_data),
             )
             res = api.product.get(code, fields=["code"])
-            self.assertEqual(res, response_data["product"])
-            self.assertEqual(mock.last_request.qs["fields"], ["code"])
+            assert res == response_data["product"]
+            assert mock.last_request.qs["fields"] == ["code"]
 
     def test_get_product_invalid_code(self):
         api = openfoodfacts.API(user_agent=TEST_USER_AGENT, version="v2")
@@ -74,7 +73,7 @@ class TestProducts(unittest.TestCase):
                 status_code=200,
             )
             res = api.product.get(code)
-            self.assertEqual(res, None)
+            assert res is None
 
             with pytest.raises(
                 ValueError,
@@ -93,7 +92,7 @@ class TestProducts(unittest.TestCase):
                 text=json.dumps(response_data),
             )
             res = api.product.text_search("kinder bueno")
-            self.assertEqual(res["products"], ["kinder bueno"])
+            assert res["products"] == ["kinder bueno"]
             response_data = {"products": ["banania", "banania big"], "count": 2}
             mock.get(
                 "https://world.openfoodfacts.org/cgi/search.pl?"
@@ -104,7 +103,7 @@ class TestProducts(unittest.TestCase):
             res = api.product.text_search(
                 "banania", page=2, page_size=10, sort_by="unique_scans"
             )
-            self.assertEqual(res["products"], ["banania", "banania big"])
+            assert res["products"] == ["banania", "banania big"]
 
     def test_parse_ingredients(self):
         api = openfoodfacts.API(user_agent=TEST_USER_AGENT, version="v2")
@@ -180,6 +179,219 @@ class TestProducts(unittest.TestCase):
             ):
                 api.product.parse_ingredients("eau, sucre", lang="fr")
 
+    def test_upload_image_success(self):
+        api = openfoodfacts.API(
+            user_agent=TEST_USER_AGENT, version="v2", username="test", password="test"
+        )
+        code = "1223435"
+        response_data = {
+            "code": "1223435",
+            "errors": [],
+            "product": {
+                "images": {
+                    "uploaded": {
+                        "1": {
+                            "imgid": 1,
+                            "sizes": {
+                                "100": {"h": 100, "w": 62},
+                                "400": {"h": 400, "w": 248},
+                                "full": {"h": 400, "w": 248},
+                            },
+                            "uploaded_t": 1758793764,
+                            "uploader": "test",
+                        }
+                    }
+                }
+            },
+            "result": {
+                "id": "image_uploaded",
+                "lc_name": "Image uploaded",
+                "name": "Image uploaded",
+            },
+            "status": "success",
+            "warnings": [],
+        }
+        with requests_mock.mock() as mock:
+            mock.post(
+                f"https://world.openfoodfacts.org/api/v3/product/{code}/images",
+                text=json.dumps(response_data),
+                status_code=200,
+            )
+            res = api.product.upload_image(code, image_data_base64="dGVzdA==")
+            assert res.status_code == 200
+            assert mock.last_request.json() == {
+                "image_data_base64": "dGVzdA==",
+                "user_id": "test",
+                "password": "test",
+            }
 
-if __name__ == "__main__":
-    unittest.main()
+    def test_upload_image_with_selected(self):
+        api = openfoodfacts.API(
+            user_agent=TEST_USER_AGENT, version="v2", username="test", password="test"
+        )
+        code = "1223435"
+        response_data = {
+            "code": "1223435",
+            "errors": [],
+            "product": {
+                "images": {
+                    "selected": {
+                        "front": {
+                            "en": {
+                                "generation": {},
+                                "imgid": 1,
+                                "rev": 2,
+                                "sizes": {
+                                    "100": {"h": 100, "w": 62},
+                                    "200": {"h": 200, "w": 124},
+                                    "400": {"h": 400, "w": 248},
+                                    "full": {"h": 400, "w": 248},
+                                },
+                            }
+                        }
+                    },
+                    "uploaded": {
+                        "1": {
+                            "imgid": 1,
+                            "sizes": {
+                                "100": {"h": 100, "w": 62},
+                                "400": {"h": 400, "w": 248},
+                                "full": {"h": 400, "w": 248},
+                            },
+                            "uploaded_t": 1758793852,
+                            "uploader": "test",
+                        }
+                    },
+                }
+            },
+            "result": {
+                "id": "image_uploaded",
+                "lc_name": "Image uploaded",
+                "name": "Image uploaded",
+            },
+            "status": "success",
+            "warnings": [],
+        }
+        with requests_mock.mock() as mock:
+            mock.post(
+                f"https://world.openfoodfacts.org/api/v3/product/{code}/images",
+                text=json.dumps(response_data),
+                status_code=200,
+            )
+            res = api.product.upload_image(
+                code, image_data_base64="dGVzdA==", selected={"front": {"en": {}}}
+            )
+            assert res.status_code == 200
+            assert mock.last_request.json() == {
+                "image_data_base64": "dGVzdA==",
+                "user_id": "test",
+                "password": "test",
+                "selected": {"front": {"en": {}}},
+            }
+
+    def test_upload_image_no_auth(self):
+        api = openfoodfacts.API(user_agent=TEST_USER_AGENT, version="v2")
+        code = "1223435"
+        with pytest.raises(
+            ValueError,
+            match="a password or a session cookie is required to upload an image",
+        ):
+            api.product.upload_image(code, image_data_base64="dGVzdA==")
+
+    def test_upload_image_invalid_code(self):
+        api = openfoodfacts.API(
+            user_agent=TEST_USER_AGENT, version="v2", username="test", password="test"
+        )
+        code = "invalidcode"
+        with pytest.raises(
+            ValueError,
+            match="code must be a numeric string",
+        ):
+            api.product.upload_image(code, image_data_base64="dGVzdA==")
+
+    def test_upload_image_no_data(self):
+        api = openfoodfacts.API(
+            user_agent=TEST_USER_AGENT, version="v2", username="test", password="test"
+        )
+        code = "1223435"
+        with pytest.raises(
+            ValueError,
+            match="one of image_path or image_data_base64 must be provided",
+        ):
+            api.product.upload_image(code)
+
+    def test_upload_image_both_data(self):
+        api = openfoodfacts.API(
+            user_agent=TEST_USER_AGENT, version="v2", username="test", password="test"
+        )
+        code = "1223435"
+        with pytest.raises(
+            ValueError,
+            match="only one of image_path or image_data_base64 must be provided",
+        ):
+            api.product.upload_image(
+                code, image_path="path/to/image.jpg", image_data_base64="dGVzdA=="
+            )
+
+    def test_upload_image_invalid_selected(self):
+        api = openfoodfacts.API(
+            user_agent=TEST_USER_AGENT, version="v2", username="test", password="test"
+        )
+        code = "1223435"
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "invalid image field name in selected: wrong (must be one of front, ingredients, nutrition, packaging)"
+            ),
+        ):
+            api.product.upload_image(
+                code, image_data_base64="dGVzdA==", selected={"wrong": {}}
+            )
+
+    def test_upload_image_with_path(self, tmp_path):
+        api = openfoodfacts.API(
+            user_agent=TEST_USER_AGENT, version="v2", username="test", password="test"
+        )
+        code = "1223435"
+        response_data = {
+            "code": "1223435",
+            "errors": [],
+            "product": {
+                "images": {
+                    "uploaded": {
+                        "1": {
+                            "imgid": 1,
+                            "sizes": {
+                                "100": {"h": 100, "w": 62},
+                                "400": {"h": 400, "w": 248},
+                                "full": {"h": 400, "w": 248},
+                            },
+                            "uploaded_t": 1758793764,
+                            "uploader": "test",
+                        }
+                    }
+                }
+            },
+            "result": {
+                "id": "image_uploaded",
+                "lc_name": "Image uploaded",
+                "name": "Image uploaded",
+            },
+            "status": "success",
+            "warnings": [],
+        }
+        image_path = tmp_path / "test_image.jpg"
+        image_path.write_bytes(b"test")
+        with requests_mock.mock() as mock:
+            mock.post(
+                f"https://world.openfoodfacts.org/api/v3/product/{code}/images",
+                text=json.dumps(response_data),
+                status_code=200,
+            )
+            res = api.product.upload_image(code, image_path=image_path)
+            assert res.status_code == 200
+            assert mock.last_request.json() == {
+                "image_data_base64": "dGVzdA==",
+                "user_id": "test",
+                "password": "test",
+            }


### PR DESCRIPTION
Implement the image upload route (v3) of Product Opener: https://openfoodfacts.github.io/openfoodfacts-server/api/ref-v3/#post-/api/v3/product/-barcode-/images