### PR TITLE
feat: add get_url method and product_update_url property #391

### DIFF
--- a/openfoodfacts/api.py
+++ b/openfoodfacts/api.py
@@ -293,7 +293,7 @@ class ProductResource:
         if not body.get("code"):
             raise ValueError("missing code from body")
 
-        url = f"{self.base_url}/cgi/product_jqm2.pl"
+        url = self.product_update_url
         return send_form_urlencoded_post_request(url, body, self.api_config)
 
     def select_image(

--- a/openfoodfacts/api.py
+++ b/openfoodfacts/api.py
@@ -193,6 +193,31 @@ class ProductResource:
             environment=api_config.environment,
             country_code=self.api_config.country.name,
         )
+    @property
+    def product_update_url(self) -> str:
+        return f"{self.base_url}/cgi/product_jqm2.pl"
+    
+    def get_url(self, code: str, fields: Optional[List[str]] = None) -> str:
+        """Return the URL used to fetch a product without making a request.
+
+        :param code: barcode of the product
+        :param fields: a list of fields to return. If None, all fields are
+            returned.
+        :return: the URL to fetch the product
+        """
+        if len(code) == 0:
+            raise ValueError("code must be a non-empty string")
+
+        fields = fields or []
+        url = f"{self.base_url}/api/{self.api_config.version.value}/product/{code}"
+
+        if fields:
+            # requests escape comma in URLs, as expected, but openfoodfacts
+            # server does not recognize escaped commas.
+            # See
+            # https://github.com/openfoodfacts/openfoodfacts-server/issues/1607
+            url += "?fields={}".format(",".join(fields))
+        return url
 
     def get(
         self,
@@ -211,18 +236,7 @@ class ProductResource:
             barcode is invalid, defaults to False.
         :return: the API response
         """
-        if len(code) == 0:
-            raise ValueError("code must be a non-empty string")
-
-        fields = fields or []
-        url = f"{self.base_url}/api/{self.api_config.version.value}/product/{code}"
-
-        if fields:
-            # requests escape comma in URLs, as expected, but openfoodfacts
-            # server does not recognize escaped commas.
-            # See
-            # https://github.com/openfoodfacts/openfoodfacts-server/issues/1607
-            url += "?fields={}".format(",".join(fields))
+        url = self.get_url(code, fields)
 
         resp = send_get_request(
             url=url, api_config=self.api_config, return_none_on_404=True


### PR DESCRIPTION
## Description
Added get_url method to ProductResource and exposed product_update_url.

## Solution
The goal of this PR is to allow users to inspect the API URLs without actually triggering a network request. Here’s how I handled it:

Extracted URL Logic: I created a new get_url method. Previously, the URL construction was hardcoded inside the get method. Now, it lives in its own reusable function.

Refactored get method: I updated the existing get method to call get_url internally. This removes code duplication and keeps the logic consistent.
<img width="957" height="313" alt="image" src="https://github.com/user-attachments/assets/c2d881f2-48a8-4969-8b2a-3d141f305909" />


Exposed Update URL: I added a product_update_url property. This gives users a direct way to see the endpoint used for product updates (/cgi/product_jqm2.pl).

Improved Flexibility: Users can now pass a list of fields to get_url to see exactly what the final query string will look like before fetching data.
<img width="878" height="145" alt="image" src="https://github.com/user-attachments/assets/c2404de4-eab1-447b-aa62-3a0b6513d163" />



## Related issue(s)

- Fixes #[391]