### PR TITLE
fix: fix bug in how we apply NMS

### DIFF
--- a/openfoodfacts/ml/object_detection.py
+++ b/openfoodfacts/ml/object_detection.py
@@ -154,6 +154,64 @@ class ObjectDetectionRawResult:
         return results
 
 
+def apply_nms(
+    bboxes: np.ndarray,
+    scores: np.ndarray,
+    classes: np.ndarray,
+    threshold: float,
+    nms_threshold: float,
+    nms_eta: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Apply the non-maximum suppression algorithm to the bounding boxes.
+
+    We use `NMSBoxes` from the openCV library to perform NMS.
+
+    :param bboxes: The bounding boxes in format [y_min, x_min, y_max, x_max], in relative
+        coordinates. Shape: (N, 4)
+    :param scores: The confidence scores. Shape: (N,)
+    :param classes: The class labels, as an int array. Shape: (N,)
+    :param threshold: The confidence threshold to use to filter out the bounding boxes.
+        Shape: (N,)
+    :param nms_threshold: The NMS threshold to use.
+    :param nms_eta: The NMS eta to use.
+    :return: bounding boxes, scores, classes after NMS
+    """
+
+    count = bboxes.shape[0]
+    bboxes_nms = np.zeros((count, 4), dtype=np.float32)
+    for i in range(count):
+        # raw_detection_boxes format: y_min, x_min, y_max, x_max
+        # expected format: x, y, width, height
+        # See Rec2d constructor:
+        # https://docs.opencv.org/4.x/javadoc/org/opencv/core/Rect2d.html#%3Cinit%3E(double,double,double,double)
+        # and NMSBoxes documentation:
+        # https://docs.opencv.org/4.x/d6/d0f/group__dnn.html#ga6e9e67e8d1d8b3a70b55ab9ea715e70d
+        bboxes_nms[i, 0] = bboxes[i, 1]  # x_min
+        bboxes_nms[i, 1] = bboxes[i, 0]  # y_min
+        bboxes_nms[i, 2] = bboxes[i, 3] - bboxes[i, 1]  # box_width
+        bboxes_nms[i, 3] = bboxes[i, 2] - bboxes[i, 0]  # box_height
+
+    detection_box_indices = dnn.NMSBoxes(
+        bboxes=bboxes_nms,  # type: ignore
+        scores=scores,  # type: ignore
+        score_threshold=threshold,  # type: ignore
+        # the following values are copied from Ultralytics settings
+        nms_threshold=nms_threshold,
+        eta=nms_eta,
+    )
+
+    detection_classes = np.zeros(len(detection_box_indices), dtype=int)
+    detection_scores = np.zeros(len(detection_box_indices), dtype=np.float32)
+    detection_boxes = np.zeros((len(detection_box_indices), 4), dtype=np.float32)
+
+    for i, idx in enumerate(detection_box_indices):
+        detection_classes[i] = classes[idx]
+        detection_scores[i] = scores[idx]
+        detection_boxes[i] = bboxes[idx]
+
+    return detection_boxes, detection_scores, detection_classes
+
+
 class ObjectDetector:
     def __init__(self, model_name: str, label_names: list[str], image_size: int = 640):
         """An object detection detector based on Yolo models.
@@ -177,6 +235,7 @@ class ObjectDetector:
         nms_threshold: float | None = None,
         nms_eta: float | None = None,
         model_version: str | None = None,
+        nms: bool = True,
     ) -> ObjectDetectionRawResult:
         """Run an object detection model on an image.
 
@@ -193,6 +252,7 @@ class ObjectDetector:
             will be used).
         :param model_version: the version of the model to use, defaults to
             None (latest).
+        :param nms: whether to use NMS, defaults to True.
         :return: the detection result
         """
         metrics: dict[str, float] = {}
@@ -221,6 +281,7 @@ class ObjectDetector:
                 original_shape=original_shape,
                 nms_threshold=nms_threshold,
                 nms_eta=nms_eta,
+                nms=nms,
             )
 
         metrics.update(response.metrics)
@@ -248,6 +309,7 @@ class ObjectDetector:
         original_shape: tuple[int, int],
         nms_threshold: float | None = None,
         nms_eta: float | None = None,
+        nms: bool = True,
     ) -> ObjectDetectionRawResult:
         """Postprocess the output of the object detection model.
 
@@ -258,6 +320,8 @@ class ObjectDetector:
             use, defaults to None (0.7 will be used).
         :param nms_eta: the NMS eta parameter to use, defaults to None (1.0
             will be used).
+        :param nms: whether to apply NMS or not, defaults to True. If False,
+           `nms_threshold` and `nms_eta` are ignored.
         :return: the detection result
         """
         if len(response.outputs) != 1:
@@ -284,15 +348,15 @@ class ObjectDetector:
         raw_detection_classes = np.zeros(rows, dtype=int)
         raw_detection_scores = np.zeros(rows, dtype=np.float32)
         raw_detection_boxes = np.zeros((rows, 4), dtype=np.float32)
-
+        selected = 0
         for i in range(rows):
             classes_scores = output[4:, i]
             max_cls_idx = np.argmax(classes_scores)
             max_score = classes_scores[max_cls_idx]
             if max_score < threshold:
                 continue
-            raw_detection_classes[i] = max_cls_idx
-            raw_detection_scores[i] = max_score
+            raw_detection_classes[selected] = max_cls_idx
+            raw_detection_scores[selected] = max_score
 
             # The bounding box is in the format (x, y, width, height) in
             # relative coordinates
@@ -313,30 +377,32 @@ class ObjectDetector:
                 original_shape=original_shape,
                 image_size=self.image_size,
             )
-            raw_detection_boxes[i, 0] = max(0.0, min(1.0, reversed_bboxes[0]))
-            raw_detection_boxes[i, 1] = max(0.0, min(1.0, reversed_bboxes[1]))
-            raw_detection_boxes[i, 2] = max(0.0, min(1.0, reversed_bboxes[2]))
-            raw_detection_boxes[i, 3] = max(0.0, min(1.0, reversed_bboxes[3]))
+            raw_detection_boxes[selected, 0] = max(0.0, min(1.0, reversed_bboxes[0]))
+            raw_detection_boxes[selected, 1] = max(0.0, min(1.0, reversed_bboxes[1]))
+            raw_detection_boxes[selected, 2] = max(0.0, min(1.0, reversed_bboxes[2]))
+            raw_detection_boxes[selected, 3] = max(0.0, min(1.0, reversed_bboxes[3]))
+            selected += 1
+
+        raw_detection_classes = raw_detection_classes[:selected]
+        raw_detection_scores = raw_detection_scores[:selected]
+        raw_detection_boxes = raw_detection_boxes[:selected]
 
         metrics: dict[str, float] = {}
-        with PerfTimer("postprocess_nms_time", metrics):
-            # Perform NMS (Non Maximum Suppression)
-            detection_box_indices = dnn.NMSBoxes(
-                raw_detection_boxes,  # type: ignore
-                raw_detection_scores,  # type: ignore
-                score_threshold=threshold,
-                # the following values are copied from Ultralytics settings
-                nms_threshold=nms_threshold,
-                eta=nms_eta,
-            )
-        detection_classes = np.zeros(len(detection_box_indices), dtype=int)
-        detection_scores = np.zeros(len(detection_box_indices), dtype=np.float32)
-        detection_boxes = np.zeros((len(detection_box_indices), 4), dtype=np.float32)
 
-        for i, idx in enumerate(detection_box_indices):
-            detection_classes[i] = raw_detection_classes[idx]
-            detection_scores[i] = raw_detection_scores[idx]
-            detection_boxes[i] = raw_detection_boxes[idx]
+        if nms:
+            with PerfTimer("postprocess_nms_time", metrics):
+                detection_boxes, detection_scores, detection_classes = apply_nms(
+                    bboxes=raw_detection_boxes,
+                    scores=raw_detection_scores,
+                    classes=raw_detection_classes,
+                    threshold=threshold,
+                    nms_threshold=nms_threshold,
+                    nms_eta=nms_eta,
+                )
+        else:
+            detection_classes = raw_detection_classes
+            detection_scores = raw_detection_scores
+            detection_boxes = raw_detection_boxes
 
         result = ObjectDetectionRawResult(
             num_detections=rows,

--- a/tests/ml/test_object_detection.py
+++ b/tests/ml/test_object_detection.py
@@ -4,7 +4,11 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from openfoodfacts.ml.object_detection import ObjectDetectionRawResult, ObjectDetector
+from openfoodfacts.ml.object_detection import (
+    ObjectDetectionRawResult,
+    ObjectDetector,
+    apply_nms,
+)
 
 
 @pytest.fixture
@@ -107,3 +111,323 @@ class TestObjectDetector:
 
         # Check the number of detections
         assert result.num_detections == 1
+
+
+class TestApplyNMS:
+    """Unit tests for the apply_nms function."""
+
+    threshold = 0.5
+    nms_threshold = 0.5
+    nms_eta = 1.0
+
+    def test_basic_nms_single_box(self):
+        """Test NMS with a single bounding box - should return unchanged."""
+        bboxes = np.array([[0.1, 0.1, 0.5, 0.5]], dtype=np.float32)
+        scores = np.array([0.9], dtype=np.float32)
+        classes = np.array([0], dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=self.threshold,
+            nms_threshold=self.nms_threshold,
+            nms_eta=self.nms_eta,
+        )
+
+        np.testing.assert_array_almost_equal(result_boxes, bboxes)
+        np.testing.assert_array_almost_equal(result_scores, scores)
+        np.testing.assert_array_equal(result_classes, classes)
+
+    def test_nms_removes_overlapping_boxes_same_class(self):
+        """Test that NMS removes overlapping boxes."""
+        # Two highly overlapping boxes
+        bboxes = np.array(
+            [
+                [0.1, 0.1, 0.5, 0.5],  # Original box
+                [0.12, 0.12, 0.52, 0.52],  # Highly overlapping, should be suppressed
+            ],
+            dtype=np.float32,
+        )
+        scores = np.array([0.9, 0.8], dtype=np.float32)
+        classes = np.array([0, 0], dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=self.threshold,
+            nms_threshold=0.5,  # Threshold low enough to suppress overlapping boxes
+            nms_eta=self.nms_eta,
+        )
+
+        # Should only keep the higher score box
+        assert len(result_boxes) == 1
+        np.testing.assert_array_almost_equal(result_boxes[0], bboxes[0])
+        assert result_scores[0] == scores[0]
+        assert result_classes[0] == classes[0]
+
+    def test_nms_keeps_non_overlapping_boxes(self):
+        """Test that NMS keeps non-overlapping boxes."""
+        bboxes = np.array(
+            [
+                [0.1, 0.1, 0.3, 0.3],  # Top-left box
+                [0.6, 0.6, 0.9, 0.9],  # Bottom-right box, no overlap
+            ],
+            dtype=np.float32,
+        )
+        scores = np.array([0.9, 0.85], dtype=np.float32)
+        classes = np.array([0, 0], dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=self.threshold,
+            nms_threshold=0.5,
+            nms_eta=self.nms_eta,
+        )
+
+        # Should keep both boxes
+        assert len(result_boxes) == 2
+        np.testing.assert_array_almost_equal(result_boxes, bboxes)
+        np.testing.assert_array_almost_equal(result_scores, scores)
+        np.testing.assert_array_equal(result_classes, classes)
+
+    def test_apply_nms_filters_by_threshold(self):
+        """Test that boxes below confidence threshold are filtered out."""
+        bboxes = np.array(
+            [
+                [0.1, 0.1, 0.5, 0.5],  # Above threshold
+                [0.6, 0.6, 0.9, 0.9],  # Below threshold
+            ],
+            dtype=np.float32,
+        )
+        scores = np.array([0.6, 0.3], dtype=np.float32)  # 0.3 < threshold=0.5
+        classes = np.array([0, 0], dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=self.threshold,
+            nms_threshold=self.nms_threshold,
+            nms_eta=self.nms_eta,
+        )
+
+        # Should only keep the box above threshold
+        assert len(result_boxes) == 1
+        np.testing.assert_array_almost_equal(result_boxes[0], bboxes[0])
+        np.testing.assert_array_almost_equal(result_scores[0], scores[0])
+
+    def test_apply_nms_empty_input(self):
+        """Test NMS with no input boxes."""
+        bboxes = np.zeros((0, 4), dtype=np.float32)
+        scores = np.zeros(0, dtype=np.float32)
+        classes = np.zeros(0, dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=self.threshold,
+            nms_threshold=self.nms_threshold,
+            nms_eta=self.nms_eta,
+        )
+
+        assert len(result_boxes) == 0
+        assert len(result_scores) == 0
+        assert len(result_classes) == 0
+
+    def test_apply_nms_all_below_threshold(self):
+        """Test NMS when all boxes are below confidence threshold."""
+        bboxes = np.array(
+            [
+                [0.1, 0.1, 0.5, 0.5],
+                [0.6, 0.6, 0.9, 0.9],
+            ],
+            dtype=np.float32,
+        )
+        scores = np.array([0.3, 0.4], dtype=np.float32)  # Both below 0.5
+        classes = np.array([0, 0], dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=self.threshold,
+            nms_threshold=self.nms_threshold,
+            nms_eta=self.nms_eta,
+        )
+
+        assert len(result_boxes) == 0
+        assert len(result_scores) == 0
+        assert len(result_classes) == 0
+
+    def test_nms_keeps_highest_score_in_cluster(self):
+        """Test that NMS keeps highest scoring box in a cluster of overlaps."""
+        # Three overlapping boxes, middle score should be suppressed
+        bboxes = np.array(
+            [
+                [0.1, 0.1, 0.6, 0.6],  # Lowest score, should be suppressed
+                [0.1, 0.1, 0.5, 0.5],  # Highest score, should be kept
+                [0.1, 0.1, 0.55, 0.55],  # Middle score, should be suppressed
+            ],
+            dtype=np.float32,
+        )
+        scores = np.array([0.7, 0.95, 0.8], dtype=np.float32)
+        classes = np.array([0, 0, 0], dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=self.threshold,
+            nms_threshold=0.5,
+            nms_eta=self.nms_eta,
+        )
+
+        # Should at least keep the highest scoring box
+        assert len(result_boxes) == 1
+        np.testing.assert_array_almost_equal(
+            result_boxes, np.array([[0.1, 0.1, 0.5, 0.5]])
+        )
+        assert result_scores[0] == 0.95
+        assert result_classes[0] == 0
+
+    def test_bbbox_format_conversion(self):
+        """Test that bbox format conversion is correct (y_min,x_min,y_max,x_max) -> (x,y,w,h)."""
+        # This test verifies the internal conversion in apply_nms
+        bboxes = np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32)  # Full image
+        scores = np.array([1.0], dtype=np.float32)
+        classes = np.array([0], dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=0.0,  # Include all
+            nms_threshold=0.5,
+            nms_eta=self.nms_eta,
+        )
+
+        # Output should preserve original format
+        np.testing.assert_array_almost_equal(result_boxes, bboxes)
+
+    def test_multiple_detections_per_class(self):
+        """Test NMS with multiple separate detections of the same class."""
+        bboxes = np.array(
+            [
+                [0.0, 0.0, 0.3, 0.3],  # Detection 1, class 0
+                [0.5, 0.5, 0.8, 0.8],  # Detection 2, class 0 (no overlap with 1)
+                [0.0, 0.5, 0.3, 0.8],  # Detection 3, class 0 (no overlap)
+            ],
+            dtype=np.float32,
+        )
+        scores = np.array([0.9, 0.85, 0.8], dtype=np.float32)
+        classes = np.array([0, 0, 0], dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=self.threshold,
+            nms_threshold=0.5,
+            nms_eta=self.nms_eta,
+        )
+
+        # All three should be kept since they don't overlap
+        assert len(result_boxes) == 3
+
+    def test_nms_threshold_extremes(self):
+        """Test NMS with extreme threshold values."""
+        bboxes = np.array(
+            [
+                [0.1, 0.1, 0.5, 0.5],
+                [0.12, 0.12, 0.52, 0.52],  # Highly overlapping
+            ],
+            dtype=np.float32,
+        )
+        scores = np.array([0.9, 0.8], dtype=np.float32)
+        classes = np.array([0, 0], dtype=int)
+
+        # Very high NMS threshold (0.99) - less suppression, keep both
+        result_high, _, _ = apply_nms(
+            bboxes=bboxes.copy(),
+            scores=scores.copy(),
+            classes=classes.copy(),
+            threshold=self.threshold,
+            nms_threshold=0.99,
+            nms_eta=self.nms_eta,
+        )
+
+        # Very low NMS threshold (0.1) - more suppression
+        result_low, _, _ = apply_nms(
+            bboxes=bboxes.copy(),
+            scores=scores.copy(),
+            classes=classes.copy(),
+            threshold=self.threshold,
+            nms_threshold=0.01,
+            nms_eta=self.nms_eta,
+        )
+
+        assert len(result_high) == 2
+        assert len(result_low) == 1
+
+    def test_return_type_correctness(self):
+        """Test that return types are correct."""
+        bboxes = np.array([[0.1, 0.1, 0.5, 0.5]], dtype=np.float32)
+        scores = np.array([0.9], dtype=np.float32)
+        classes = np.array([0], dtype=int)
+
+        result_boxes, result_scores, result_classes = apply_nms(
+            bboxes=bboxes,
+            scores=scores,
+            classes=classes,
+            threshold=self.threshold,
+            nms_threshold=self.nms_threshold,
+            nms_eta=self.nms_eta,
+        )
+
+        assert isinstance(result_boxes, np.ndarray)
+        assert isinstance(result_scores, np.ndarray)
+        assert isinstance(result_classes, np.ndarray)
+        assert result_boxes.dtype == np.float32
+        assert result_scores.dtype == np.float32
+        assert result_classes.dtype == int
+        assert result_boxes.shape[1] == 4  # (N, 4) shape
+
+    def test_nms_eta_effect(self):
+        """Test that nms_eta parameter is passed correctly."""
+        bboxes = np.array(
+            [
+                [0.1, 0.1, 0.5, 0.5],
+                [0.2, 0.2, 0.6, 0.6],
+            ],
+            dtype=np.float32,
+        )
+        scores = np.array([0.9, 0.8], dtype=np.float32)
+        classes = np.array([0, 0], dtype=int)
+
+        # Different eta values
+        result_eta_1, _, _ = apply_nms(
+            bboxes=bboxes.copy(),
+            scores=scores.copy(),
+            classes=classes.copy(),
+            threshold=self.threshold,
+            nms_threshold=0.5,
+            nms_eta=1.0,
+        )
+
+        result_eta_05, _, _ = apply_nms(
+            bboxes=bboxes.copy(),
+            scores=scores.copy(),
+            classes=classes.copy(),
+            threshold=self.threshold,
+            nms_threshold=0.5,
+            nms_eta=0.5,
+        )
+
+        # Just verify they run without error and return valid shapes
+        assert result_eta_1.shape[1] == 4
+        assert result_eta_05.shape[1] == 4


### PR DESCRIPTION
The bboxes we provided to NMSBoxes didn't have the right format: we provided the bounding box as `(y_min, x_min, y_max, x_max)` while `NMSBoxes` expects it as `(x_min, y_min, width, height)`.

I fixed the issue, and:

- added a `nms` parameter to enable/disable NMS for easier debugging
- exported the NMS logic in an `apply_nms` function
- added many unit tests