### PR TITLE
feat: finish rudimentary folksonomy tag CRUD support

### DIFF
--- a/src/openfoodfacts/api.py
+++ b/src/openfoodfacts/api.py
@@ -385,13 +385,13 @@ class FolksonomyResource:
 
     def get(
         self,
-        code: str,
+        product: str,
         owner: str | None = None,
         keys: Sequence | str | None = None,
     ) -> requests.Response:
         """Retrieve folksonomy tags for a product.
 
-        :param code: the product barcode
+        :param product: the product barcode
         :param owner: the tag owner; requires authentication as that user.
             Case-sensitive. Leave empty for public tags (default).
         :param keys: List of keys to filter by. Can be provided as either
@@ -407,7 +407,7 @@ class FolksonomyResource:
                 keys = ",".join(keys)
             params["keys"] = keys
         r = _send_request(
-            url=f"{self.base_url}/product/{code}",
+            url=f"{self.base_url}/product/{product}",
             api_config=self.api_config,
             method="GET",
             params=params,
@@ -417,7 +417,7 @@ class FolksonomyResource:
 
     def add(
         self,
-        code: str,
+        product: str,
         key: str,
         value: str,
         version: Literal[1] | None = None,
@@ -425,7 +425,7 @@ class FolksonomyResource:
     ) -> requests.Response:
         """Add a folksonomy tag to a product.
 
-        :param code: the product barcode
+        :param product: the product barcode
         :param key: the key for the tag
         :param value: the value to set for the tag
         :param version: version of the tag. Should be None or 1.
@@ -433,7 +433,7 @@ class FolksonomyResource:
             Case-sensitive. Leave empty for public tags (default).
         :return: the API response"""
         params: dict[str, str | int] = dict()
-        params["product"] = code
+        params["product"] = product
         params["k"] = key
         params["v"] = value
         if version:
@@ -451,7 +451,7 @@ class FolksonomyResource:
 
     def update(
         self,
-        code: str,
+        product: str,
         key: str,
         value: str,
         version: int,
@@ -459,7 +459,7 @@ class FolksonomyResource:
     ) -> requests.Response:
         """Update a folksonomy tag on a product.
 
-        :param code: the product barcode
+        :param product: the product barcode
         :param key: the key for the tag
         :param value: the value to set for the tag
         :param version: must be equal to previous version + 1
@@ -467,7 +467,7 @@ class FolksonomyResource:
             Case-sensitive. Leave empty for public tags (default).
         :return: the API response"""
         params: dict[str, str | int] = dict()
-        params["product"] = code
+        params["product"] = product
         params["k"] = key
         params["v"] = value
         params["version"] = version
@@ -484,14 +484,14 @@ class FolksonomyResource:
 
     def delete(
         self,
-        code: str,
+        product: str,
         key: str,
         version: int,
         owner: str | None = None,
     ) -> requests.Response:
         """Delete a folksonomy tag on a product.
 
-        :param code: the product barcode
+        :param product: the product barcode
         :param key: the key to delete
         :param version: the version the tag is at
         :param owner: the tag owner; requires authentication as that user.
@@ -502,7 +502,7 @@ class FolksonomyResource:
         if owner:
             params["owner"] = owner
         r = _send_request(
-            url=f"{self.base_url}/product/{code}/{key}",
+            url=f"{self.base_url}/product/{product}/{key}",
             api_config=self.api_config,
             method="DELETE",
             params=params,

--- a/src/openfoodfacts/api.py
+++ b/src/openfoodfacts/api.py
@@ -415,6 +415,101 @@ class FolksonomyResource:
         assert r is not None
         return r
 
+    def add(
+        self,
+        code: str,
+        key: str,
+        value: str,
+        version: Literal[1] | None = None,
+        owner: str | None = None,
+    ) -> requests.Response:
+        """Add a folksonomy tag to a product.
+
+        :param code: the product barcode
+        :param key: the key for the tag
+        :param value: the value to set for the tag
+        :param version: version of the tag. Should be None or 1.
+        :param owner: the tag owner; requires authentication as that user.
+            Case-sensitive. Leave empty for public tags (default).
+        :return: the API response"""
+        params: dict[str, str | int] = dict()
+        params["product"] = code
+        params["k"] = key
+        params["v"] = value
+        if version:
+            params["version"] = version
+        if owner:
+            params["owner"] = owner
+        r = _send_request(
+            url=f"{self.base_url}/product",
+            api_config=self.api_config,
+            method="POST",
+            json=params,
+        )
+        assert r is not None
+        return r
+
+    def update(
+        self,
+        code: str,
+        key: str,
+        value: str,
+        version: int,
+        owner: str | None = None,
+    ) -> requests.Response:
+        """Update a folksonomy tag on a product.
+
+        :param code: the product barcode
+        :param key: the key for the tag
+        :param value: the value to set for the tag
+        :param version: must be equal to previous version + 1
+        :param owner: the tag owner; requires authentication as that user.
+            Case-sensitive. Leave empty for public tags (default).
+        :return: the API response"""
+        params: dict[str, str | int] = dict()
+        params["product"] = code
+        params["k"] = key
+        params["v"] = value
+        params["version"] = version
+        if owner:
+            params["owner"] = owner
+        r = _send_request(
+            url=f"{self.base_url}/product",
+            api_config=self.api_config,
+            method="PUT",
+            json=params,
+        )
+        assert r is not None
+        return r
+
+    def delete(
+        self,
+        code: str,
+        key: str,
+        version: int,
+        owner: str | None = None,
+    ) -> requests.Response:
+        """Delete a folksonomy tag on a product.
+
+        :param code: the product barcode
+        :param key: the key to delete
+        :param version: the version the tag is at
+        :param owner: the tag owner; requires authentication as that user.
+            Case-sensitive. Leave empty for public tags (default).
+        :return: the API response"""
+        params: dict[str, str | int] = dict()
+        params["version"] = version
+        if owner:
+            params["owner"] = owner
+        r = _send_request(
+            url=f"{self.base_url}/product/{code}/{key}",
+            api_config=self.api_config,
+            method="DELETE",
+            params=params,
+        )
+        assert r is not None
+        return r
+
 
 class ProductResource:
     def __init__(self, api_config: APIConfig):

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -407,7 +407,7 @@ class TestFolksonomy:
 
     def test_get_with_entries(self):
         api = openfoodfacts.API(user_agent=TEST_USER_AGENT)
-        code = "7311043021598"
+        product = "7311043021598"
         response_data = [
             {
                 "product": "7311043021598",
@@ -462,11 +462,11 @@ class TestFolksonomy:
         ]
         with requests_mock.mock() as mock:
             mock.get(
-                f"https://api.folksonomy.openfoodfacts.org/product/{code}",
+                f"https://api.folksonomy.openfoodfacts.org/product/{product}",
                 text=json.dumps(response_data),
                 status_code=200,
             )
-            res = api.folksonomy.get(code)
+            res = api.folksonomy.get(product)
             assert res.status_code == 200
             assert len(res.json()) == 5
 


### PR DESCRIPTION
## Description

- There are projects that want to use [Folksonomy engine](https://wiki.openfoodfacts.org/Folksonomy_Engine) to contribute to Open Food Facts, but the Python SDK currently only supports getting(/**r**etrieving) tag information.

## Solution

- This adds remaining basic CUD (create, update, delete) methods for folksonomy tags centered around products.

## Related issue(s)

- Depends on https://github.com/openfoodfacts/openfoodfacts-python/pull/499
- Fixes https://github.com/openfoodfacts/openfoodfacts-python/issues/315
- Closes https://github.com/openfoodfacts/openfoodfacts-python/pull/325