### PR TITLE
refactor: move NutritionV3 from robotoff to SDK

### DIFF
--- a/openfoodfacts/types.py
+++ b/openfoodfacts/types.py
@@ -1,7 +1,7 @@
 import enum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 #: A precise expectation of what mappings looks like in json.
 #: (dict where keys are always of type `str`).
@@ -913,3 +913,97 @@ class TaxonomyType(str, enum.Enum):
     origin = "origin"
     language = "language"
     other_nutritional_substance = "other_nutritional_substance"
+
+
+class NutritionV3NutrientAggregated(BaseModel):
+    value: float
+    unit: str = Field(description="Normalized unit", examples=["g", "kJ", "kcal", "%"])
+    modifier: str | None = None
+    source: str = Field(examples=["packaging", "manufacturer", "estimate", "usda"])
+    source_per: Literal["serving", "100g", "100ml"]
+    source_index: int
+
+
+class NutritionV3NutrientInput(BaseModel):
+    unit: str
+    value: float | None = None
+    value_computed: float | None = None
+    value_string: str | None = None
+    modifier: str | None = None
+
+
+class NutritionV3AggregatedSet(BaseModel):
+    preparation: Literal["as_sold", "prepared"]
+    per: Literal["100g", "100ml"]
+    nutrients: dict[str, NutritionV3NutrientAggregated] = Field(default_factory=dict)
+
+
+class NutritionV3InputSet(BaseModel):
+    preparation: Literal["as_sold", "prepared"]
+    per: Literal["serving", "100g", "100ml"]
+    per_quantity: int
+    per_unit: Literal["g", "ml"]
+    source: str = Field(
+        examples=["packaging", "manufacturer", "database-usda", "estimate"]
+    )
+    source_description: str | None = None
+    last_updated_t: int | None = Field(
+        None, description="timestamp of the last update of the input set"
+    )
+    nutrients: dict[str, NutritionV3NutrientInput] = Field(
+        default_factory=dict, description="Mapping from nutrient name to its value"
+    )
+    unspecified_nutrients: list[str] = Field(
+        default_factory=list,
+        description="List of unspecified nutrients (ex: not provided on the packaging)",
+    )
+
+
+class NutritionV3(BaseModel):
+    """New `nutrition` field of products, which come with schema_version 1003."""
+
+    aggregated_set: NutritionV3AggregatedSet | None = None
+    input_sets: list[NutritionV3InputSet] = Field(default_factory=list)
+
+    def filter_input_sets(
+        self,
+        per: str | None = None,
+        preparation: str | None = None,
+        per_quantity: int | None = None,
+        per_unit: str | None = None,
+        source: str | None = None,
+    ) -> list["NutritionV3InputSet"]:
+        results = self.input_sets
+        if per is not None:
+            results = [s for s in results if s.per == per]
+        if preparation is not None:
+            results = [s for s in results if s.preparation == preparation]
+        if per_quantity is not None:
+            results = [s for s in results if s.per_quantity == per_quantity]
+        if per_unit is not None:
+            results = [s for s in results if s.per_unit == per_unit]
+        if source is not None:
+            results = [s for s in results if s.source == source]
+        return results
+
+    def get_input_nutrient(
+        self,
+        nutrient: str,
+        per: str | None = None,
+        preparation: str | None = None,
+        per_quantity: int | None = None,
+        per_unit: str | None = None,
+        source: str | None = None,
+    ) -> NutritionV3NutrientInput | None:
+        filtered_sets = self.filter_input_sets(
+            per=per,
+            preparation=preparation,
+            per_quantity=per_quantity,
+            per_unit=per_unit,
+            source=source,
+        )
+        if not filtered_sets:
+            return None
+
+        input_set = filtered_sets[0]
+        return input_set.nutrients.get(nutrient)

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,6 +1,6 @@
 import pytest
 
-from openfoodfacts.types import Flavor
+from openfoodfacts.types import Flavor, JSONType, NutritionV3, NutritionV3InputSet
 
 
 def test_from_product_type_food():
@@ -24,3 +24,299 @@ def test_from_product_type_invalid():
         ValueError, match="no Flavor matched with product_type 'invalid'"
     ):
         Flavor.from_product_type("invalid")
+
+
+NUTRITION_1 = {
+    "aggregated_set": {
+        "nutrients": {
+            "salt": {
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "serving",
+                "unit": "g",
+                "value": 0.5,
+            },
+            "saturated-fat": {
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "serving",
+                "unit": "g",
+                "value": 0.5,
+            },
+        },
+        "per": "100g",
+        "preparation": "as_sold",
+    },
+    "input_sets": [
+        {
+            "nutrients": {
+                "salt": {"unit": "g", "value": 1, "value_string": "1"},
+                "saturated-fat": {
+                    "unit": "g",
+                    "value": 1,
+                    "value_string": "1",
+                },
+            },
+            "per": "serving",
+            "per_quantity": 200,
+            "per_unit": "g",
+            "preparation": "as_sold",
+            "source": "packaging",
+        }
+    ],
+}
+
+NUTRITION_2 = {
+    "aggregated_set": {
+        "nutrients": {
+            "salt": {
+                "modifier": "<=",
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 5,
+            },
+            "sodium": {
+                "modifier": "<=",
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 2,
+            },
+            "sugars": {
+                "source": "usda",
+                "source_index": 1,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 5.2,
+            },
+        },
+        "per": "100g",
+        "preparation": "as_sold",
+    },
+    "input_sets": [
+        {
+            "nutrients": {
+                "sodium": {
+                    "modifier": "<=",
+                    "unit": "g",
+                    "value": 2,
+                    "value_string": "2.0",
+                }
+            },
+            "per": "100g",
+            "per_quantity": "100",
+            "per_unit": "g",
+            "preparation": "as_sold",
+            "source": "packaging",
+        },
+        {
+            "nutrients": {
+                "sodium": {
+                    "unit": "g",
+                    "value": 0.1,
+                    "value_string": "0.1",
+                },
+                "sugars": {
+                    "unit": "g",
+                    "value": 5.2,
+                    "value_string": "5.2",
+                },
+            },
+            "per": "100g",
+            "per_quantity": "100",
+            "per_unit": "g",
+            "preparation": "as_sold",
+            "source": "usda",
+        },
+    ],
+}
+
+
+# With `value_computed` in the input_set
+NUTRITION_3 = {
+    "aggregated_set": {
+        "nutrients": {
+            "carbohydrates": {
+                "modifier": "<",
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 0.5,
+            },
+            "energy": {
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "kJ",
+                "value": 332,
+                "value_computed": 340.4,
+            },
+            "energy-kcal": {
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "kcal",
+                "value": 78,
+                "value_computed": 80.3,
+            },
+            "energy-kj": {
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "kJ",
+                "value": 332,
+                "value_computed": 340.4,
+            },
+            "fat": {
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 0.7,
+            },
+            "proteins": {
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 18,
+            },
+            "salt": {
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 1.2,
+            },
+            "saturated-fat": {
+                "modifier": "<",
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 0.1,
+            },
+            "sodium": {
+                "modifier": "~",
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 0.48,
+            },
+            "sugars": {
+                "modifier": "<",
+                "source": "packaging",
+                "source_index": 0,
+                "source_per": "100g",
+                "unit": "g",
+                "value": 0.5,
+            },
+        },
+        "per": "100g",
+        "preparation": "as_sold",
+    },
+    "input_sets": [
+        {
+            "nutrients": {
+                "carbohydrates": {
+                    "modifier": "<",
+                    "unit": "g",
+                    "value": 0.5,
+                    "value_string": "0.5",
+                },
+                "energy-kcal": {
+                    "unit": "kcal",
+                    "value": 78,
+                    "value_computed": 80.3,
+                    "value_string": "78",
+                },
+                "energy-kj": {
+                    "unit": "kJ",
+                    "value": 332,
+                    "value_computed": 340.4,
+                    "value_string": "332",
+                },
+                "fat": {"unit": "g", "value": 0.7, "value_string": "0.7"},
+                "proteins": {"unit": "g", "value": 18, "value_string": "18"},
+                "salt": {"unit": "g", "value": 1.2, "value_string": "1.2"},
+                "saturated-fat": {
+                    "modifier": "<",
+                    "unit": "g",
+                    "value": 0.1,
+                    "value_string": "0.1",
+                },
+                "sodium": {"unit": "g", "value_computed": 0.48},
+                "sugars": {
+                    "modifier": "<",
+                    "unit": "g",
+                    "value": 0.5,
+                    "value_string": "0.5",
+                },
+            },
+            "per": "100g",
+            "per_quantity": 100,
+            "per_unit": "g",
+            "preparation": "as_sold",
+            "source": "packaging",
+            "unspecified_nutrients": ["fiber"],
+        }
+    ],
+}
+
+
+class TestNutritionV3:
+    @pytest.mark.parametrize("obj", [NUTRITION_1, NUTRITION_2, NUTRITION_3])
+    def test_parse(self, obj: JSONType):
+        NutritionV3.model_validate(obj)
+
+    def test_filter_input_sets(self):
+        nutrition_obj = NutritionV3.model_validate(NUTRITION_2)
+        results = nutrition_obj.filter_input_sets(source="packaging")
+        assert len(results) == 1
+        assert isinstance(results[0], NutritionV3InputSet)
+        assert (
+            len(nutrition_obj.filter_input_sets(source="packaging", per="100ml")) == 0
+        )
+
+    def test_get_input_nutrient(self):
+        nutrition_obj = NutritionV3.model_validate(NUTRITION_2)
+        result = nutrition_obj.get_input_nutrient(
+            nutrient="sodium",
+            per="100g",
+            preparation="as_sold",
+            per_quantity=100,
+            source="packaging",
+            per_unit="g",
+        )
+        assert result is not None
+        assert result.value == 2
+        assert result.value_string == "2.0"
+        assert result.unit == "g"
+        assert result.modifier == "<="
+
+        # We expect no result here
+        result = nutrition_obj.get_input_nutrient(
+            nutrient="sodium",
+            # per was modified here
+            per="serving",
+            preparation="as_sold",
+            per_quantity=100,
+            source="packaging",
+            per_unit="g",
+        )
+        assert result is None
+
+        result = nutrition_obj.get_input_nutrient(
+            nutrient="sugars",
+            source="usda",
+        )
+        assert result is not None
+        assert result.value == 5.2
+        assert result.value_string == "5.2"
+        assert result.unit == "g"
+        assert result.modifier is None


### PR DESCRIPTION
The Pydantic models are used in Robotoff and openfoodfacts-export.