### PR TITLE
ci: fix: update paths in configuration files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
-source = ./openfoodfacts
-omit = ./venv/*,*tests*
+source = ./src/openfoodfacts
+omit = ./.venv/*,*tests*
 
 [report]
-omit = ./venv/*,*tests*,*mi
+omit = ./.venv/*,*tests*,*mi

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,31 +4,27 @@ github_actions:
 
 REDIS:
 - changed-files:
-  - any-glob-to-any-file: 'tests/test_redis.py'
-  - any-glob-to-any-file: 'openfoodfacts/redis.py'
+  - any-glob-to-any-file: 'tests/**/test_redis.py'
+  - any-glob-to-any-file: 'src/openfoodfacts/redis.py'
 
 images:
 - changed-files:
-  - any-glob-to-any-file: 'openfoodfacts/images.py'
-  - any-glob-to-any-file: 'tests/​test_images.py'
+  - any-glob-to-any-file: 'src/openfoodfacts/images.py'
+  - any-glob-to-any-file: 'tests/**/test_images.py'
 
 OCR:
 - changed-files:
-  - any-glob-to-any-file: 'tests/​test_ocr.py'
+  - any-glob-to-any-file: 'tests/**/test_ocr.py'
 
 tests:
 - changed-files:
-  - any-glob-to-any-file: 'tests/test_utils.py'
-  - any-glob-to-any-file: 'tests/test_api.py'
-  - any-glob-to-any-file: 'tests/test_ocr.py'
-  - any-glob-to-any-file: 'tests/test_redis.py'
-  - any-glob-to-any-file: 'tests/test_images.py'
-  - any-glob-to-any-file: 'tests/test_api_config.py'
+  - any-glob-to-any-file: 'tests/**/*'
 
 utils:
 - changed-files:
-  - any-glob-to-any-file: 'openfoodfacts/utils.py'
-  - any-glob-to-any-file: 'tests/test_utils.py'
+  - any-glob-to-any-file: 'src/openfoodfacts/utils.py'
+  - any-glob-to-any-file: 'tests/**/test_utils.py'
+  - any-glob-to-any-file: 'tests/unit/utils/**/*'
 
 dependencies:
 - changed-files:
@@ -36,5 +32,4 @@ dependencies:
 
 documentation:
 - changed-files:
-  - any-glob-to-any-file: 'handle_taxonomies.md'
-  - any-glob-to-any-file: 'usage.md'
+  - any-glob-to-any-file: 'docs/**/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Python SDK quality checks and unit tests
 on:
   push:
     paths:
-      - "openfoodfacts/**"
+      - "src/**"
       - "pyproject.toml"
       - "uv.lock"
       - "tests/**"


### PR DESCRIPTION
## Description

- The library recently moved to a `src/` structure, but CI related files were not updated as part of this change.

## Solution

- This updates CI files referring to the previous `./openfoodfacts` directory by pointing to `./src/openfoodfacts` or `./src` instead.

## Related issue(s)

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-python/pull/434