### PR TITLE
docs: add chocolate search example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ results = api.product.update({
 
 with `CODE` the product barcode. The rest of the body should be a dictionary of fields to create/update.
 
+# Search example
+results = api.product.text_search("chocolate")
+print(results["products"][0]["product_name"])
+
 To see all possible capabilities, check out the [usage guide](https://openfoodfacts.github.io/openfoodfacts-python/usage/).
 
 


### PR DESCRIPTION
Added a small example demonstrating how to search for chocolate products using the Open Food Facts Python SDK.

This improves the documentation by showing another simple usage example of the text_search API.