### PR TITLE
feat: add clean_string utility function with unit tests

### DIFF
--- a/src/openfoodfacts/utils/__init__.py
+++ b/src/openfoodfacts/utils/__init__.py
@@ -15,6 +15,12 @@ from typing import Callable, Dict, Iterable, List, Optional, Union
 import requests
 import tqdm
 
+# src/openfoodfacts/utils/__init__.py
+from .string_helpers import clean_string
+
+__all__ = ["clean_string"]
+
+
 from ..types import COUNTRY_CODE_TO_NAME, Country, Environment, Flavor
 
 _orjson_available = True

--- a/src/openfoodfacts/utils/string_helpers.py
+++ b/src/openfoodfacts/utils/string_helpers.py
@@ -1,0 +1,11 @@
+def clean_string(s: str) -> str:
+    """
+    Cleans a string by stripping whitespace and converting to lowercase.
+
+    Args:
+        s (str): Input string.
+
+    Returns:
+        str: Cleaned string or None if input is None.
+    """
+    return s.strip().lower() if s else s

--- a/tests/unit/utils/test_string_helpers.py
+++ b/tests/unit/utils/test_string_helpers.py
@@ -1,0 +1,9 @@
+
+import pytest
+from openfoodfacts.utils import clean_string
+
+def test_clean_string():
+    assert clean_string(" Hello ") == "hello"
+    assert clean_string("WORLD") == "world"
+    assert clean_string("") == ""
+    assert clean_string(None) is None


### PR DESCRIPTION
## Description
 
This PR brings a new utility function "clean_string" which is located in the utils module.
It performs basic string normalization by:-
   1) Trimming leading and trailing whitespace.
   2) Converting strings to lowercase
The string_helper can be very useful for consistent preprocessing of textual fields like product names or ingredient lists. 

## Changes

1) Added "clean_string" function in the utils module. (`src/openfoodfacts/utils/string_helpers.py`)
2) Exported the function in '__init__.py' file which comes under src and utils. (`src/openfoodfacts/utils/__init__.py`)
3) Added unit tests in the tests folder with file name of 'test_string_helpers.py'. (`tests/unit/utils/test_string_helpers.py`)

## Testing

All tests were passed locally using pytest.