### PR TITLE
docs: fix typo in README: instanciated → instantiated

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ or manually from source:
 
 ## Examples
 
-All the examples below assume that you have imported the SDK and instanciated the API object:
+All the examples below assume that you have imported the SDK and instantiated the API object:
 
 ```python
 import openfoodfacts


### PR DESCRIPTION
This PR fixes a typo in the README file by correcting  "instanciated" to "instantiated".

## Description

- Brief note about the issue

## Solution

- Mention how your solution resolves the issue

## Related issue(s)

- Fixes #[ISSUE NUMBER]