### PR TITLE
feat: add paginated category retrieval using static taxonomy (#106)

### DIFF
--- a/src/openfoodfacts/api.py
+++ b/src/openfoodfacts/api.py
@@ -1,3 +1,4 @@
+
 import base64
 import logging
 import typing
@@ -9,7 +10,7 @@ import requests
 
 from .types import APIConfig, APIVersion, Country, Environment, Facet, Flavor, JSONType
 from .utils import URLBuilder, http_session
-
+from .taxonomy import get_taxonomy
 logger = logging.getLogger(__name__)
 
 
@@ -170,11 +171,27 @@ class FacetResource:
         r = _send_request(
             url=f"{self.base_url}/facets/{facet_plural}",
             params={"json": "1", "page": page, "page_size": page_size, **kwargs},
-            api_config=self.api_config,
-            method="GET",
+            api_config=self.api_config,  # <--- Make sure these line up
+            method="GET",                # <--- with the 'url' line above
         )
         return typing.cast(requests.Response, r).json()
 
+    def get_categories(
+        self, 
+        page: int = 1, 
+        page_size: int = 20
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch categories from the high-performance static taxonomy.
+        Supports pagination by slicing the local list.
+        """
+        taxonomy = get_taxonomy("category")
+        all_nodes = list(taxonomy.iter_nodes())
+        
+        start = (page - 1) * page_size
+        end = start + page_size
+        
+        return [node.to_dict() for node in all_nodes[start:end]]
     def get_products(
         self,
         facet_name: Union[Facet, str],

--- a/tests/unit/test_facets.py
+++ b/tests/unit/test_facets.py
@@ -1,0 +1,63 @@
+
+
+
+
+
+
+
+
+
+
+
+
+from unittest.mock import patch, Mock
+from openfoodfacts.api import FacetResource 
+
+def test_get_categories_pagination():
+    """
+    Test that get_categories properly paginates the static taxonomy 
+    without hitting the live API.
+    """
+    # 1. Create a mock object to represent the Taxonomy class
+    mock_taxonomy_obj = Mock()
+    
+    # 2. Helper function to create mock nodes that possess a .to_dict() method
+    def create_mock_node(category_id, name):
+        node = Mock()
+        node.to_dict.return_value = {"id": category_id, "name": name}
+        return node
+
+    # 3. Create our 5 mock nodes
+    mock_nodes = [
+        create_mock_node("en:category1", "Category 1"),
+        create_mock_node("en:category2", "Category 2"),
+        create_mock_node("en:category3", "Category 3"),
+        create_mock_node("en:category4", "Category 4"),
+        create_mock_node("en:category5", "Category 5"),
+    ]
+
+    # 4. Tell the taxonomy mock to return our mock nodes
+    mock_taxonomy_obj.iter_nodes.return_value = mock_nodes
+
+    # 5. Patch get_taxonomy to return our custom mock object
+    with patch('openfoodfacts.api.get_taxonomy', return_value=mock_taxonomy_obj):
+        
+        fake_config = Mock()
+        resource = FacetResource(api_config=fake_config)
+
+        # Test Page 1 (Should return the first 2 items)
+        page1 = resource.get_categories(page=1, page_size=2)
+        assert len(page1) == 2, "Page 1 should return exactly 2 items"
+        assert page1[0]["id"] == "en:category1"
+        
+        # Test Page 2 (Should return the next 2 items)
+        page2 = resource.get_categories(page=2, page_size=2)
+        assert len(page2) == 2, "Page 2 should return exactly 2 items"
+        assert page2[0]["id"] == "en:category3"
+        
+        # Test Page 3 (Should return the remaining 1 item)
+        page3 = resource.get_categories(page=3, page_size=2)
+        assert len(page3) == 1, "Page 3 should return the 1 remaining item"
+
+        # Ensure the items are actually different
+        assert page1 != page2, "Page 1 and Page 2 should have different categories"


### PR DESCRIPTION
Overview
This PR addresses Issue #106. The previous implementation for category retrieval was hitting the live API, which frequently returns 503 Service Unavailable errors due to the heavy load of the taxonomy.

Changes

Implemented get_categories within FacetResource using the high-performance static taxonomy (get_taxonomy("category")).

Added support for pagination (page and page_size) to allow efficient data fetching without overloading the client.

Verified the fix locally using the project's source code; it successfully retrieves categories (e.g., "Beef", "Asenovgrad") without server timeouts.

Testing
Confirmed functionality with a standalone test script by forcing PYTHONPATH=src to ensure the local changes were active.