### PR TITLE
feat(Taxonomy): allow fetching taxonomies from other flavors (obf, opff, opf)

### DIFF
--- a/src/openfoodfacts/taxonomy.py
+++ b/src/openfoodfacts/taxonomy.py
@@ -395,7 +395,9 @@ class Taxonomy:
         return cls.from_dict(data)
 
     @classmethod
-    def from_type(cls, taxonomy_type: TaxonomyType, flavor: Flavor = Flavor.off) -> "Taxonomy":
+    def from_type(
+        cls, taxonomy_type: TaxonomyType, flavor: Flavor = Flavor.off
+    ) -> "Taxonomy":
         """Create a Taxonomy from a taxonomy file hosted online from a
         taxonomy type.
 

--- a/src/openfoodfacts/taxonomy.py
+++ b/src/openfoodfacts/taxonomy.py
@@ -70,27 +70,27 @@ TAXONOMY_URLS = {
         + "/data/taxonomies/other_nutritional_substances.full.json",
     },
     Flavor.obf: {
-        TaxonomyType.category: URLBuilder.static(Flavor.opf, Environment.org)
+        TaxonomyType.category: URLBuilder.static(Flavor.obf, Environment.org)
         + "/data/taxonomies/categories.full.json",
-        TaxonomyType.ingredient: URLBuilder.static(Flavor.off, Environment.org)
+        TaxonomyType.ingredient: URLBuilder.static(Flavor.obf, Environment.org)
         + "/data/taxonomies/ingredients.full.json",
-        TaxonomyType.label: URLBuilder.static(Flavor.off, Environment.org)
+        TaxonomyType.label: URLBuilder.static(Flavor.obf, Environment.org)
         + "/data/taxonomies/labels.full.json",
-        TaxonomyType.brand: URLBuilder.static(Flavor.off, Environment.org)
+        TaxonomyType.brand: URLBuilder.static(Flavor.obf, Environment.org)
         + "/data/taxonomies/brands.full.json",
-        TaxonomyType.allergen: URLBuilder.static(Flavor.off, Environment.org)
+        TaxonomyType.allergen: URLBuilder.static(Flavor.obf, Environment.org)
         + "/data/taxonomies/allergens.full.json",
     },
     Flavor.opff: {
-        TaxonomyType.category: URLBuilder.static(Flavor.opf, Environment.org)
+        TaxonomyType.category: URLBuilder.static(Flavor.opff, Environment.org)
         + "/data/taxonomies/categories.full.json",
-        TaxonomyType.ingredient: URLBuilder.static(Flavor.off, Environment.org)
+        TaxonomyType.ingredient: URLBuilder.static(Flavor.opff, Environment.org)
         + "/data/taxonomies/ingredients.full.json",
     },
     Flavor.opf: {
         TaxonomyType.category: URLBuilder.static(Flavor.opf, Environment.org)
         + "/data/taxonomies/categories.full.json",
-        TaxonomyType.label: URLBuilder.static(Flavor.off, Environment.org)
+        TaxonomyType.label: URLBuilder.static(Flavor.opf, Environment.org)
         + "/data/taxonomies/labels.full.json",
         TaxonomyType.brand: URLBuilder.static(Flavor.opf, Environment.org)
         + "/data/taxonomies/brands.full.json",

--- a/src/openfoodfacts/taxonomy.py
+++ b/src/openfoodfacts/taxonomy.py
@@ -23,50 +23,55 @@ DEFAULT_CACHE_DIR = Path("~/.cache/openfoodfacts/taxonomy").expanduser()
 
 # Only available for Open Food Facts for now (not other flavors)
 TAXONOMY_URLS = {
-    TaxonomyType.category: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/categories.full.json",
-    TaxonomyType.ingredient: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/ingredients.full.json",
-    TaxonomyType.label: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/labels.full.json",
-    TaxonomyType.brand: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/brands.full.json",
-    TaxonomyType.packaging_shape: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/packaging_shapes.full.json",
-    TaxonomyType.packaging_material: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/packaging_materials.full.json",
-    TaxonomyType.packaging_recycling: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/packaging_recycling.full.json",
-    TaxonomyType.country: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/countries.full.json",
-    TaxonomyType.store: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/stores.full.json",
-    TaxonomyType.nova_group: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/nova_groups.full.json",
-    TaxonomyType.additive: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/additives.full.json",
-    TaxonomyType.vitamin: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/vitamins.full.json",
-    TaxonomyType.mineral: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/minerals.full.json",
-    TaxonomyType.amino_acid: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/amino_acids.full.json",
-    TaxonomyType.nucleotide: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/nucleotides.full.json",
-    TaxonomyType.allergen: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/allergens.full.json",
-    TaxonomyType.state: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/states.full.json",
-    TaxonomyType.data_quality: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/data_quality.full.json",
-    TaxonomyType.origin: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/origins.full.json",
-    TaxonomyType.language: URLBuilder.static(Flavor.off, Environment.org)
-    + "/data/taxonomies/languages.full.json",
-    TaxonomyType.other_nutritional_substance: URLBuilder.static(
-        Flavor.off, Environment.org
-    )
-    + "/data/taxonomies/other_nutritional_substances.full.json",
+    Flavor.off: {
+        TaxonomyType.category: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/categories.full.json",
+        TaxonomyType.ingredient: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/ingredients.full.json",
+        TaxonomyType.label: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/labels.full.json",
+        TaxonomyType.brand: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/brands.full.json",
+        TaxonomyType.packaging_shape: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/packaging_shapes.full.json",
+        TaxonomyType.packaging_material: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/packaging_materials.full.json",
+        TaxonomyType.packaging_recycling: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/packaging_recycling.full.json",
+        TaxonomyType.country: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/countries.full.json",
+        TaxonomyType.store: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/stores.full.json",
+        TaxonomyType.nova_group: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/nova_groups.full.json",
+        TaxonomyType.additive: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/additives.full.json",
+        TaxonomyType.vitamin: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/vitamins.full.json",
+        TaxonomyType.mineral: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/minerals.full.json",
+        TaxonomyType.amino_acid: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/amino_acids.full.json",
+        TaxonomyType.nucleotide: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/nucleotides.full.json",
+        TaxonomyType.allergen: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/allergens.full.json",
+        TaxonomyType.state: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/states.full.json",
+        TaxonomyType.data_quality: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/data_quality.full.json",
+        TaxonomyType.origin: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/origins.full.json",
+        TaxonomyType.language: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/languages.full.json",
+        TaxonomyType.other_nutritional_substance: URLBuilder.static(
+            Flavor.off, Environment.org
+        )
+        + "/data/taxonomies/other_nutritional_substances.full.json",
+    },
+    Flavor.obf: {},
+    Flavor.opff: {},
+    Flavor.opf: {},
 }
 
 
@@ -367,29 +372,32 @@ class Taxonomy:
         return cls.from_dict(data)
 
     @classmethod
-    def from_type(cls, taxonomy_type: TaxonomyType) -> "Taxonomy":
+    def from_type(cls, taxonomy_type: TaxonomyType, flavor: Flavor = Flavor.off) -> "Taxonomy":
         """Create a Taxonomy from a taxonomy file hosted online from a
         taxonomy type.
 
         :param taxonomy_type: the taxonomy type
+        :param flavor: The data source, defaults to Flavor.off
         :return: a Taxonomy
         """
-        url = TAXONOMY_URLS[TaxonomyType[taxonomy_type]]
+        url = TAXONOMY_URLS[flavor][TaxonomyType[taxonomy_type]]
         return cls.from_url(url)
 
 
 def get_taxonomy(
     taxonomy_type: TaxonomyType | str,
+    flavor: Flavor = Flavor.off,
     force_download: bool = False,
     download_newer: bool = False,
     cache_dir: Path | None = None,
     tmp_dir: Path | None = None,
 ) -> Taxonomy:
-    """Return the taxonomy of the provided type.
+    """Return the taxonomy of the provided type & flavor.
 
     The taxonomy file is downloaded and cached locally.
 
     :param taxonomy_type: the requested taxonomy type
+    :param flavor: The data source, defaults to Flavor.off
     :param force_download: if True, (re)download the taxonomy even if it was
         cached, defaults to False
     :param download_newer: if True, download the taxonomy if a more recent
@@ -403,11 +411,11 @@ def get_taxonomy(
     :return: a Taxonomy
     """
     taxonomy_type = TaxonomyType[taxonomy_type]
-    filename = f"{taxonomy_type.name}.json"
+    filename = f"{flavor.name}-{taxonomy_type.name}.json"
 
     cache_dir = DEFAULT_CACHE_DIR if cache_dir is None else cache_dir
     taxonomy_path = cache_dir / filename
-    url = TAXONOMY_URLS[taxonomy_type]
+    url = TAXONOMY_URLS[flavor][taxonomy_type]
 
     if not should_download_file(url, taxonomy_path, force_download, download_newer):
         return Taxonomy.from_path(taxonomy_path)

--- a/src/openfoodfacts/taxonomy.py
+++ b/src/openfoodfacts/taxonomy.py
@@ -21,7 +21,6 @@ logger = get_logger(__name__)
 DEFAULT_CACHE_DIR = Path("~/.cache/openfoodfacts/taxonomy").expanduser()
 
 
-# Only available for Open Food Facts for now (not other flavors)
 TAXONOMY_URLS = {
     Flavor.off: {
         TaxonomyType.category: URLBuilder.static(Flavor.off, Environment.org)

--- a/src/openfoodfacts/taxonomy.py
+++ b/src/openfoodfacts/taxonomy.py
@@ -69,9 +69,32 @@ TAXONOMY_URLS = {
         )
         + "/data/taxonomies/other_nutritional_substances.full.json",
     },
-    Flavor.obf: {},
-    Flavor.opff: {},
-    Flavor.opf: {},
+    Flavor.obf: {
+        TaxonomyType.category: URLBuilder.static(Flavor.opf, Environment.org)
+        + "/data/taxonomies/categories.full.json",
+        TaxonomyType.ingredient: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/ingredients.full.json",
+        TaxonomyType.label: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/labels.full.json",
+        TaxonomyType.brand: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/brands.full.json",
+        TaxonomyType.allergen: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/allergens.full.json",
+    },
+    Flavor.opff: {
+        TaxonomyType.category: URLBuilder.static(Flavor.opf, Environment.org)
+        + "/data/taxonomies/categories.full.json",
+        TaxonomyType.ingredient: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/ingredients.full.json",
+    },
+    Flavor.opf: {
+        TaxonomyType.category: URLBuilder.static(Flavor.opf, Environment.org)
+        + "/data/taxonomies/categories.full.json",
+        TaxonomyType.label: URLBuilder.static(Flavor.off, Environment.org)
+        + "/data/taxonomies/labels.full.json",
+        TaxonomyType.brand: URLBuilder.static(Flavor.opf, Environment.org)
+        + "/data/taxonomies/brands.full.json",
+    },
 }
 
 


### PR DESCRIPTION
## Description

Similar to #223, extend the `get_taxonomy` logic to allow fetching taxonomies for non-off favors.

## Solution

- Update the `get_taxonomy()` logic
  - new `flavor` param, defaults to `off`
- Update the `TAXONOMY_URLS` dict
  - add available obf, opff  & opf taxonomies
  - fyi obf also as `body_parts.full.json` but this can be done in a another PR later

## Related issue(s)

- Fixes #465