### PR TITLE
feat(Taxonomy): children method parity with parent methods

### DIFF
--- a/src/openfoodfacts/taxonomy.py
+++ b/src/openfoodfacts/taxonomy.py
@@ -129,6 +129,18 @@ class TaxonomyNode:
         """
         return candidate.is_child_of(self)
 
+    def is_child_of_any(self, candidates: Iterable["TaxonomyNode"]) -> bool:
+        """Return True if `self` is a child of any of `candidates`, False
+        otherwise.
+
+        :param candidates: an iterable of TaxonomyNodes of the same Taxonomy
+        """
+        for candidate in candidates:
+            if candidate.is_parent_of(self):
+                return True
+
+        return False
+
     def is_parent_of_any(self, candidates: Iterable["TaxonomyNode"]) -> bool:
         """Return True if `self` is a parent of any of `candidates`, False
         otherwise.
@@ -140,6 +152,26 @@ class TaxonomyNode:
                 return True
 
         return False
+
+    def get_children_hierarchy(self) -> List["TaxonomyNode"]:
+        """Return the list of all child nodes (direct and indirect)."""
+        all_children = []
+        seen: Set[str] = set()
+
+        if not self.children:
+            return []
+
+        for self_child in self.children:
+            if self_child.id not in seen:
+                all_children.append(self_child)
+                seen.add(self_child.id)
+
+            for child_child in self_child.get_children_hierarchy():
+                if child_child.id not in seen:
+                    all_children.append(child_child)
+                    seen.add(child_child.id)
+
+        return all_children
 
     def get_parents_hierarchy(self) -> List["TaxonomyNode"]:
         """Return the list of all parent nodes (direct and indirect)."""

--- a/src/openfoodfacts/taxonomy.py
+++ b/src/openfoodfacts/taxonomy.py
@@ -289,6 +289,36 @@ class Taxonomy:
 
         return [node for node in nodes if node.id not in excluded]
 
+    def is_child_of_any(
+        self, item: str, candidates: Iterable[str], raises: bool = True
+    ) -> bool:
+        """Return True if `item` is child of any candidate, False otherwise.
+
+        If the item is not in the taxonomy and raises is False, return False.
+
+        :param item: The item to compare
+        :param candidates: A list of candidates
+        :param raises: if True, raises a ValueError if item is not in the
+        taxonomy, defaults to True.
+        """
+        node: TaxonomyNode = self[item]
+
+        if node is None:
+            if raises:
+                raise ValueError("unknown id in taxonomy: %s", node)
+            else:
+                return False
+
+        to_check_nodes: Set[TaxonomyNode] = set()
+
+        for candidate in candidates:
+            candidate_node = self[candidate]
+
+            if candidate_node is not None:
+                to_check_nodes.add(candidate_node)
+
+        return node.is_child_of_any(to_check_nodes)
+
     def is_parent_of_any(
         self, item: str, candidates: Iterable[str], raises: bool = True
     ) -> bool:

--- a/tests/unit/test_taxonomy.py
+++ b/tests/unit/test_taxonomy.py
@@ -233,6 +233,35 @@ class TestTaxonomy:
     @pytest.mark.parametrize(
         "taxonomy,item,output",
         [
+            (category_taxonomy, "en:brown-camargue-rices", set()),
+            (
+                category_taxonomy,
+                "en:cooked-brown-rices",
+                {"en:unsalted-cooked-brown-rices"},
+            ),
+            (
+                category_taxonomy,
+                "en:brown-rices",
+                {
+                    "en:brown-jasmine-rices",
+                    "en:brown-basmati-rices",
+                    "en:brown-camargue-rices",
+                    "en:cooked-brown-rices",
+                    "en:unsalted-cooked-brown-rices",
+                },
+            ),
+        ],
+    )
+    def test_get_children_hierarchy(
+        self, taxonomy: Taxonomy, item: str, output: set[str]
+    ):
+        node = taxonomy[item]
+        children_list = node.get_children_hierarchy()
+        assert set((x.id for x in children_list)) == output
+
+    @pytest.mark.parametrize(
+        "taxonomy,item,output",
+        [
             (category_taxonomy, "en:plant-based-foods-and-beverages", set()),
             (
                 category_taxonomy,
@@ -258,8 +287,8 @@ class TestTaxonomy:
         self, taxonomy: Taxonomy, item: str, output: set[str]
     ):
         node = taxonomy[item]
-        parents = node.get_parents_hierarchy()
-        assert set((x.id for x in parents)) == output
+        parents_list = node.get_parents_hierarchy()
+        assert set((x.id for x in parents_list)) == output
 
     @pytest.mark.parametrize(
         "taxonomy,items,output",

--- a/tests/unit/test_taxonomy.py
+++ b/tests/unit/test_taxonomy.py
@@ -173,30 +173,60 @@ class TestTaxonomy:
     @pytest.mark.parametrize(
         "taxonomy,item,candidates,output",
         [
-            (label_taxonomy, "en:organic", {"en:fr-bio-01"}, True),
-            (label_taxonomy, "en:fr-bio-01", {"en:organic"}, False),
+            (label_taxonomy, "en:fr-bio-01", {"en:organic"}, True),
+            (label_taxonomy, "en:organic", {"en:fr-bio-01"}, False),
             (label_taxonomy, "en:fr-bio-01", [], False),
-            (label_taxonomy, "en:organic", {"en:gluten-free"}, False),
+            (label_taxonomy, "en:no-gluten", {"en:organic"}, False),
             (
                 label_taxonomy,
-                "en:organic",
-                {"en:gluten-free", "en:no-additives", "en:vegan"},
+                "en:no-gluten",
+                {"en:organic", "en:no-additives", "en:vegan"},
                 False,
             ),
             (
                 label_taxonomy,
-                "en:organic",
-                {"en:gluten-free", "en:no-additives", "en:fr-bio-16"},
+                "en:fr-bio-16",
+                {"en:organic", "en:no-gluten", "en:no-additives", "en:vegan"},
                 True,
             ),
         ],
     )
     def test_is_child_of_any(
-        self, taxonomy: Taxonomy, item: str, candidates: list, output: bool
+        self, taxonomy: Taxonomy, item: str, candidates: list[str], output: bool
+    ):
+        assert taxonomy.is_child_of_any(item, candidates) is output
+
+    def test_is_child_of_any_unknown_item(self):
+        with pytest.raises(ValueError):
+            label_taxonomy.is_child_of_any("unknown-id", set())
+
+    @pytest.mark.parametrize(
+        "taxonomy,item,candidates,output",
+        [
+            (label_taxonomy, "en:organic", {"en:fr-bio-01"}, True),
+            (label_taxonomy, "en:fr-bio-01", {"en:organic"}, False),
+            (label_taxonomy, "en:fr-bio-01", [], False),
+            (label_taxonomy, "en:organic", {"en:no-gluten"}, False),
+            (
+                label_taxonomy,
+                "en:organic",
+                {"en:no-gluten", "en:no-additives", "en:vegan"},
+                False,
+            ),
+            (
+                label_taxonomy,
+                "en:organic",
+                {"en:no-gluten", "en:no-additives", "en:fr-bio-16"},
+                True,
+            ),
+        ],
+    )
+    def test_is_parent_of_any(
+        self, taxonomy: Taxonomy, item: str, candidates: list[str], output: bool
     ):
         assert taxonomy.is_parent_of_any(item, candidates) is output
 
-    def test_is_child_of_any_unknwon_item(self):
+    def test_is_parent_of_any_unknown_item(self):
         with pytest.raises(ValueError):
             label_taxonomy.is_parent_of_any("unknown-id", set())
 


### PR DESCRIPTION
## Description

- There are currently a handful of functions that handle parentage lookups. Two of these methods currently only exist for parents and are a lacking a “child” equivalent.

## Solution

- This adds `TaxonomyNode.is_child_of()` and `.get_children_hierarchy()`, copying the logic of their `parent[s]` method equivalents.

## Related issue(s)

- https://github.com/openfoodfacts/open-prices/pull/1261 is basically duplicating this logic