### PR TITLE
chore(pre-commit): add --fix flag to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,8 @@ repos:
   - id: reuse-lint-file
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.15.0
+  rev: v0.15.12
   hooks:
-  # Run the linter.
-  - id: ruff-check
-  # Run the formatter.
-  - id: ruff-format
+  - id: ruff-check  # linter
+    args: [--fix]
+  - id: ruff-format  # formatter


### PR DESCRIPTION
## Description

Following #472
`ruff` was in the `pre-commit` config but not actually fixing issues.

## Solution

- Add `--fix` flag

## Related issue(s)

- Fixes #468