### PR TITLE
refactor(Taxonomy): replace TAXONOMY_URLS with TAXONOMY_MAPPING and a single method to build the url

### DIFF
--- a/src/openfoodfacts/taxonomy.py
+++ b/src/openfoodfacts/taxonomy.py
@@ -21,47 +21,51 @@ logger = get_logger(__name__)
 DEFAULT_CACHE_DIR = Path("~/.cache/openfoodfacts/taxonomy").expanduser()
 
 
-TAXONOMY_URLS = {
-    Flavor.off: {
-        TaxonomyType.category: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.category.dataset_path}",
-        TaxonomyType.ingredient: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.ingredient.dataset_path}",
-        TaxonomyType.label: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.label.dataset_path}",
-        TaxonomyType.brand: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.brand.dataset_path}",
-        TaxonomyType.packaging_shape: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.packaging_shape.dataset_path}",
-        TaxonomyType.packaging_material: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.packaging_material.dataset_path}",
-        TaxonomyType.packaging_recycling: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.packaging_recycling.dataset_path}",
-        TaxonomyType.country: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.country.dataset_path}",
-        TaxonomyType.store: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.store.dataset_path}",
-        TaxonomyType.nova_group: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.nova_group.dataset_path}",
-        TaxonomyType.additive: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.additive.dataset_path}",
-        TaxonomyType.vitamin: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.vitamin.dataset_path}",
-        TaxonomyType.mineral: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.mineral.dataset_path}",
-        TaxonomyType.amino_acid: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.amino_acid.dataset_path}",
-        TaxonomyType.nucleotide: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.nucleotide.dataset_path}",
-        TaxonomyType.allergen: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.allergen.dataset_path}",
-        TaxonomyType.state: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.state.dataset_path}",
-        TaxonomyType.data_quality: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.data_quality.dataset_path}",
-        TaxonomyType.origin: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.origin.dataset_path}",
-        TaxonomyType.language: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.language.dataset_path}",
-        TaxonomyType.other_nutritional_substance: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.other_nutritional_substance.dataset_path}",
-    },
-    Flavor.obf: {
-        TaxonomyType.category: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.category.dataset_path}",
-        TaxonomyType.ingredient: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.ingredient.dataset_path}",
-        TaxonomyType.label: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.label.dataset_path}",
-        TaxonomyType.brand: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.brand.dataset_path}",
-        TaxonomyType.allergen: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.allergen.dataset_path}",
-    },
-    Flavor.opff: {
-        TaxonomyType.category: f"{URLBuilder.static(Flavor.opff, Environment.org)}/{TaxonomyType.category.dataset_path}",
-        TaxonomyType.ingredient: f"{URLBuilder.static(Flavor.opff, Environment.org)}/{TaxonomyType.ingredient.dataset_path}",
-    },
-    Flavor.opf: {
-        TaxonomyType.category: f"{URLBuilder.static(Flavor.opf, Environment.org)}/{TaxonomyType.category.dataset_path}",
-        TaxonomyType.label: f"{URLBuilder.static(Flavor.opf, Environment.org)}/{TaxonomyType.label.dataset_path}",
-        TaxonomyType.brand: f"{URLBuilder.static(Flavor.opf, Environment.org)}/{TaxonomyType.brand.dataset_path}",
-    },
+TAXONOMY_MAPPING = {
+    Flavor.off: (
+        TaxonomyType.category,
+        TaxonomyType.ingredient,
+        TaxonomyType.label,
+        TaxonomyType.brand,
+        TaxonomyType.packaging_shape,
+        TaxonomyType.packaging_material,
+        TaxonomyType.packaging_recycling,
+        TaxonomyType.country,
+        TaxonomyType.store,
+        TaxonomyType.nova_group,
+        TaxonomyType.additive,
+        TaxonomyType.vitamin,
+        TaxonomyType.mineral,
+        TaxonomyType.amino_acid,
+        TaxonomyType.nucleotide,
+        TaxonomyType.allergen,
+        TaxonomyType.state,
+        TaxonomyType.data_quality,
+        TaxonomyType.origin,
+        TaxonomyType.language,
+        TaxonomyType.other_nutritional_substance,
+    ),
+    Flavor.obf: (
+        TaxonomyType.category,
+        TaxonomyType.ingredient,
+        TaxonomyType.label,
+        TaxonomyType.brand,
+        TaxonomyType.allergen,
+    ),
+    Flavor.opff: (
+        TaxonomyType.category,
+        TaxonomyType.ingredient,
+    ),
+    Flavor.opf: (
+        TaxonomyType.category,
+        TaxonomyType.label,
+        TaxonomyType.brand,
+    ),
 }
+
+
+def _generate_file_path(taxonomy_type: TaxonomyType, flavor: Flavor):
+    return f"{URLBuilder.static(flavor, Environment.org)}/{taxonomy_type.dataset_path}"
 
 
 class TaxonomyNode:
@@ -433,7 +437,7 @@ class Taxonomy:
         :param flavor: The data source, defaults to Flavor.off
         :return: a Taxonomy
         """
-        url = TAXONOMY_URLS[flavor][TaxonomyType[taxonomy_type]]
+        url = _generate_file_path(taxonomy_type, flavor)
         return cls.from_url(url)
 
 
@@ -468,7 +472,7 @@ def get_taxonomy(
 
     cache_dir = DEFAULT_CACHE_DIR if cache_dir is None else cache_dir
     taxonomy_path = cache_dir / filename
-    url = TAXONOMY_URLS[flavor][taxonomy_type]
+    url = _generate_file_path(taxonomy_type, flavor)
 
     if not should_download_file(url, taxonomy_path, force_download, download_newer):
         return Taxonomy.from_path(taxonomy_path)

--- a/src/openfoodfacts/taxonomy.py
+++ b/src/openfoodfacts/taxonomy.py
@@ -23,76 +23,43 @@ DEFAULT_CACHE_DIR = Path("~/.cache/openfoodfacts/taxonomy").expanduser()
 
 TAXONOMY_URLS = {
     Flavor.off: {
-        TaxonomyType.category: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/categories.full.json",
-        TaxonomyType.ingredient: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/ingredients.full.json",
-        TaxonomyType.label: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/labels.full.json",
-        TaxonomyType.brand: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/brands.full.json",
-        TaxonomyType.packaging_shape: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/packaging_shapes.full.json",
-        TaxonomyType.packaging_material: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/packaging_materials.full.json",
-        TaxonomyType.packaging_recycling: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/packaging_recycling.full.json",
-        TaxonomyType.country: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/countries.full.json",
-        TaxonomyType.store: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/stores.full.json",
-        TaxonomyType.nova_group: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/nova_groups.full.json",
-        TaxonomyType.additive: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/additives.full.json",
-        TaxonomyType.vitamin: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/vitamins.full.json",
-        TaxonomyType.mineral: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/minerals.full.json",
-        TaxonomyType.amino_acid: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/amino_acids.full.json",
-        TaxonomyType.nucleotide: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/nucleotides.full.json",
-        TaxonomyType.allergen: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/allergens.full.json",
-        TaxonomyType.state: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/states.full.json",
-        TaxonomyType.data_quality: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/data_quality.full.json",
-        TaxonomyType.origin: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/origins.full.json",
-        TaxonomyType.language: URLBuilder.static(Flavor.off, Environment.org)
-        + "/data/taxonomies/languages.full.json",
-        TaxonomyType.other_nutritional_substance: URLBuilder.static(
-            Flavor.off, Environment.org
-        )
-        + "/data/taxonomies/other_nutritional_substances.full.json",
+        TaxonomyType.category: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.category.dataset_path}",
+        TaxonomyType.ingredient: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.ingredient.dataset_path}",
+        TaxonomyType.label: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.label.dataset_path}",
+        TaxonomyType.brand: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.brand.dataset_path}",
+        TaxonomyType.packaging_shape: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.packaging_shape.dataset_path}",
+        TaxonomyType.packaging_material: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.packaging_material.dataset_path}",
+        TaxonomyType.packaging_recycling: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.packaging_recycling.dataset_path}",
+        TaxonomyType.country: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.country.dataset_path}",
+        TaxonomyType.store: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.store.dataset_path}",
+        TaxonomyType.nova_group: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.nova_group.dataset_path}",
+        TaxonomyType.additive: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.additive.dataset_path}",
+        TaxonomyType.vitamin: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.vitamin.dataset_path}",
+        TaxonomyType.mineral: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.mineral.dataset_path}",
+        TaxonomyType.amino_acid: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.amino_acid.dataset_path}",
+        TaxonomyType.nucleotide: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.nucleotide.dataset_path}",
+        TaxonomyType.allergen: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.allergen.dataset_path}",
+        TaxonomyType.state: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.state.dataset_path}",
+        TaxonomyType.data_quality: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.data_quality.dataset_path}",
+        TaxonomyType.origin: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.origin.dataset_path}",
+        TaxonomyType.language: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.language.dataset_path}",
+        TaxonomyType.other_nutritional_substance: f"{URLBuilder.static(Flavor.off, Environment.org)}/{TaxonomyType.other_nutritional_substance.dataset_path}",
     },
     Flavor.obf: {
-        TaxonomyType.category: URLBuilder.static(Flavor.obf, Environment.org)
-        + "/data/taxonomies/categories.full.json",
-        TaxonomyType.ingredient: URLBuilder.static(Flavor.obf, Environment.org)
-        + "/data/taxonomies/ingredients.full.json",
-        TaxonomyType.label: URLBuilder.static(Flavor.obf, Environment.org)
-        + "/data/taxonomies/labels.full.json",
-        TaxonomyType.brand: URLBuilder.static(Flavor.obf, Environment.org)
-        + "/data/taxonomies/brands.full.json",
-        TaxonomyType.allergen: URLBuilder.static(Flavor.obf, Environment.org)
-        + "/data/taxonomies/allergens.full.json",
+        TaxonomyType.category: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.category.dataset_path}",
+        TaxonomyType.ingredient: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.ingredient.dataset_path}",
+        TaxonomyType.label: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.label.dataset_path}",
+        TaxonomyType.brand: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.brand.dataset_path}",
+        TaxonomyType.allergen: f"{URLBuilder.static(Flavor.obf, Environment.org)}/{TaxonomyType.allergen.dataset_path}",
     },
     Flavor.opff: {
-        TaxonomyType.category: URLBuilder.static(Flavor.opff, Environment.org)
-        + "/data/taxonomies/categories.full.json",
-        TaxonomyType.ingredient: URLBuilder.static(Flavor.opff, Environment.org)
-        + "/data/taxonomies/ingredients.full.json",
+        TaxonomyType.category: f"{URLBuilder.static(Flavor.opff, Environment.org)}/{TaxonomyType.category.dataset_path}",
+        TaxonomyType.ingredient: f"{URLBuilder.static(Flavor.opff, Environment.org)}/{TaxonomyType.ingredient.dataset_path}",
     },
     Flavor.opf: {
-        TaxonomyType.category: URLBuilder.static(Flavor.opf, Environment.org)
-        + "/data/taxonomies/categories.full.json",
-        TaxonomyType.label: URLBuilder.static(Flavor.opf, Environment.org)
-        + "/data/taxonomies/labels.full.json",
-        TaxonomyType.brand: URLBuilder.static(Flavor.opf, Environment.org)
-        + "/data/taxonomies/brands.full.json",
+        TaxonomyType.category: f"{URLBuilder.static(Flavor.opf, Environment.org)}/{TaxonomyType.category.dataset_path}",
+        TaxonomyType.label: f"{URLBuilder.static(Flavor.opf, Environment.org)}/{TaxonomyType.label.dataset_path}",
+        TaxonomyType.brand: f"{URLBuilder.static(Flavor.opf, Environment.org)}/{TaxonomyType.brand.dataset_path}",
     },
 }
 

--- a/src/openfoodfacts/types.py
+++ b/src/openfoodfacts/types.py
@@ -893,16 +893,6 @@ class DatasetType(str, enum.Enum):
 class TaxonomyType(str, enum.Enum):
     dataset_filename: str
 
-    def __new__(cls, value: str, dataset_filename: str):
-        """
-        Override __new__ to allow storing the dataset filename
-        associated with each taxonomy type.
-        """
-        obj = str.__new__(cls, value)
-        obj._value_ = value
-        obj.dataset_filename = dataset_filename
-        return obj
-
     category = ("category", "categories.full.json")
     ingredient = ("ingredient", "ingredients.full.json")
     label = ("label", "labels.full.json")
@@ -928,6 +918,16 @@ class TaxonomyType(str, enum.Enum):
         "other_nutritional_substance",
         "other_nutritional_substances.full.json",
     )
+
+    def __new__(cls, value: str, dataset_filename: str):
+        """
+        Override __new__ to allow storing the dataset filename
+        associated with each taxonomy type.
+        """
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        obj.dataset_filename = dataset_filename
+        return obj
 
     @property
     def dataset_path(self) -> str:

--- a/src/openfoodfacts/types.py
+++ b/src/openfoodfacts/types.py
@@ -891,28 +891,43 @@ class DatasetType(str, enum.Enum):
 
 
 class TaxonomyType(str, enum.Enum):
-    category = "category"
-    ingredient = "ingredient"
-    label = "label"
-    brand = "brand"
-    packaging_shape = "packaging_shape"
-    packaging_material = "packaging_material"
-    packaging_recycling = "packaging_recycling"
-    country = "country"
-    store = "store"
-    nova_group = "nova_group"
-    packaging = "packaging"
-    additive = "additive"
-    vitamin = "vitamin"
-    mineral = "mineral"
-    amino_acid = "amino_acid"
-    nucleotide = "nucleotide"
-    allergen = "allergen"
-    state = "state"
-    data_quality = "data_quality"
-    origin = "origin"
-    language = "language"
-    other_nutritional_substance = "other_nutritional_substance"
+
+    def __new__(cls, value: str, dataset_filename: str):
+        """
+        Override __new__ to allow storing the dataset filename
+        associated with each taxonomy type.
+        """
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        obj.dataset_filename = dataset_filename
+        return obj
+
+    category = ("category", "categories.full.json")
+    ingredient = ("ingredient", "ingredients.full.json")
+    label = ("label", "labels.full.json")
+    brand = ("brand", "brands.full.json")
+    packaging_shape = ("packaging_shape", "packaging_shapes.full.json")
+    packaging_material = ("packaging_material", "packaging_materials.full.json")
+    packaging_recycling = ("packaging_recycling", "packaging_recycling.full.json")
+    country = ("country", "countries.full.json")
+    store = ("store", "stores.full.json")
+    nova_group = ("nova_group", "nova_groups.full.json")
+    packaging = ("packaging", "packaging.full.json")
+    additive = ("additive", "additives.full.json")
+    vitamin = ("vitamin", "vitamins.full.json")
+    mineral = ("mineral", "minerals.full.json")
+    amino_acid = ("amino_acid", "amino_acids.full.json")
+    nucleotide = ("nucleotide", "nucleotides.full.json")
+    allergen = ("allergen", "allergens.full.json")
+    state = ("state", "states.full.json")
+    data_quality = ("data_quality", "data_quality.full.json")
+    origin = ("origin", "origins.full.json")
+    language = ("language", "languages.full.json")
+    other_nutritional_substance = ("other_nutritional_substance", "other_nutritional_substances.full.json")
+
+    @property
+    def dataset_path(self) -> str:
+        return f"data/taxonomies/{self.dataset_filename}"
 
 
 class NutritionV3NutrientAggregated(BaseModel):

--- a/src/openfoodfacts/types.py
+++ b/src/openfoodfacts/types.py
@@ -891,7 +891,6 @@ class DatasetType(str, enum.Enum):
 
 
 class TaxonomyType(str, enum.Enum):
-
     def __new__(cls, value: str, dataset_filename: str):
         """
         Override __new__ to allow storing the dataset filename
@@ -923,7 +922,10 @@ class TaxonomyType(str, enum.Enum):
     data_quality = ("data_quality", "data_quality.full.json")
     origin = ("origin", "origins.full.json")
     language = ("language", "languages.full.json")
-    other_nutritional_substance = ("other_nutritional_substance", "other_nutritional_substances.full.json")
+    other_nutritional_substance = (
+        "other_nutritional_substance",
+        "other_nutritional_substances.full.json",
+    )
 
     @property
     def dataset_path(self) -> str:

--- a/src/openfoodfacts/types.py
+++ b/src/openfoodfacts/types.py
@@ -891,6 +891,8 @@ class DatasetType(str, enum.Enum):
 
 
 class TaxonomyType(str, enum.Enum):
+    dataset_filename: str
+
     def __new__(cls, value: str, dataset_filename: str):
         """
         Override __new__ to allow storing the dataset filename


### PR DESCRIPTION
## Description

Following #466

## Solution

- `TaxonomyType` type: add a new `dataset_filename` key & `dataset_path` property
- replace TAXONOMY_URLS with TAXONOMY_MAPPING
- new `_generate_file_path` and use both TAXONOMY_MAPPING & TaxonomyType.dataset_path

## Related issue(s)

- #465