### PR TITLE
feat(Auth): Added support for keycloak access_token

### DIFF
--- a/src/openfoodfacts/api.py
+++ b/src/openfoodfacts/api.py
@@ -58,6 +58,10 @@ def _send_request(
         request_args["cookies"] = request_args.get("cookies", dict()) | {
             "session": api_config.session_cookie,
         }
+    elif api_config.access_token:
+        request_args["headers"] = request_args.get("headers", dict()) | {
+            "Authorization": f"Bearer {api_config.access_token}",
+        }
     if "auth" not in request_args:
         request_args["auth"] = get_http_auth(api_config.environment)
 
@@ -595,6 +599,7 @@ class API:
         environment: Union[Environment, str] = Environment.org,
         session_cookie: Optional[str] = None,
         timeout: int = 10,
+        access_token: Optional[str] = None,
     ) -> None:
         """Initialize the API instance.
 
@@ -615,6 +620,8 @@ class API:
         :param session_cookie: a session cookie, only used for write requests,
             defaults to None
         :param timeout: the timeout for HTTP requests, defaults to 10 seconds
+        :param access_token: a keycloak access token, generated with single sign on,
+            only used for write requests, defaults to None
         """
         if not isinstance(country, Country):
             country = Country[country]
@@ -632,6 +639,7 @@ class API:
             password=password,
             session_cookie=session_cookie,
             timeout=timeout,
+            access_token=access_token,
         )
         self.password = password
         self.country = country

--- a/src/openfoodfacts/types.py
+++ b/src/openfoodfacts/types.py
@@ -861,6 +861,7 @@ class APIConfig(BaseModel):
     password: Optional[str] = None
     session_cookie: Optional[str] = None
     timeout: float = 10.0
+    access_token: Optional[str] = None
 
     @model_validator(mode="after")
     def check_credentials(self):
@@ -875,7 +876,14 @@ class APIConfig(BaseModel):
             raise ValueError(
                 "username/password and session_cookie are mutually exclusive"
             )
-
+        if self.username and self.access_token:
+            raise ValueError(
+                "username/password and access_token are mutually exclusive"
+            )
+        if self.session_cookie and self.access_token:
+            raise ValueError(
+                "session_cookie and access_token are mutually exclusive"
+            )
         return self
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Description

- Openfoodfacts api now supports access_token authentication using 'Authorization: Bearer <access_token>' header.
- This PR offers a third way to auth users (after username/password and session_cookie).

## Testing
- I haven't added unit tests, since existing auth tests are mocked anyways
- Also, there seem to be differences in the way OFF environments handle the authorization header. The header is ignored in '.net' env, but works well in '.org' env.