### PR TITLE
feat: add search-a-licious endpoint support

### DIFF
--- a/src/openfoodfacts/api.py
+++ b/src/openfoodfacts/api.py
@@ -222,6 +222,7 @@ class ProductResource:
             environment=api_config.environment,
             country_code=self.api_config.country.name,
         )
+        self.base_search_url = URLBuilder.search(self.api_config.environment)
 
     def get(
         self,
@@ -308,6 +309,35 @@ class ProductResource:
             method="GET",
         )
         return typing.cast(requests.Response, r).json()
+
+    def search(
+        self,
+        query: str,
+        page: int = 1,
+        page_size: int = 24,
+        sort_by: Optional[str] = None,
+    ) -> JSONType:
+        """Search products using the search-a-licious endpoint.
+
+        .. warning::
+            This feature is in alpha. The search-a-licious API may
+            change without notice.
+
+        :param query: the search query
+        :param page: page number (starts at 1), defaults to 1
+        :param page_size: number of results per page, defaults to 24
+        :param sort_by: field to sort by, optional
+        :return: search results dict with a 'hits' key containing products
+        """
+        params: dict = {"q": query, "page": page, "page_size": page_size}
+        if sort_by is not None:
+            params["sort_by"] = sort_by
+        resp = http_session.get(
+            f"{self.base_search_url}/search",
+            params=params,
+        )
+        resp.raise_for_status()
+        return typing.cast(JSONType, resp.json())
 
     def update(self, body: Dict[str, Any]):
         """Create a new product or update an existing one."""

--- a/src/openfoodfacts/utils/__init__.py
+++ b/src/openfoodfacts/utils/__init__.py
@@ -127,6 +127,11 @@ class URLBuilder:
             base_domain=flavor.get_base_domain(),
         )
 
+    @staticmethod
+    def search(environment: Environment) -> str:
+        domain = "net" if environment == Environment.net else "org"
+        return f"https://search.openfoodfacts.{domain}"
+
 
 def jsonl_iter(jsonl_path: Union[str, Path]) -> Iterable[Dict]:
     """Iterate over elements of a JSONL file.


### PR DESCRIPTION
## Description
Adds support for the search-a-licious endpoint at search.openfoodfacts.org.

## Changes
- Added `URLBuilder.search()` static method in `utils/__init__.py`
- Added `search()` method to `ProductResource` in `api.py`
- Supports `query`, `page`, `page_size`, and optional `sort_by` parameters

## Related Issue
Fixes #314

## Notes
This is a clean rebase of #415 on current develop, resolving all merge 
conflicts. Updated to use ruff formatting and src layout.