### PR TITLE
ci: fix `merge-conflict-autolabel` Github Action

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   assign-author:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.1


### PR DESCRIPTION
## Description

Avoid errors in the `develop` branch

<img width="1008" height="421" alt="image" src="https://github.com/user-attachments/assets/c692c539-0017-492f-9c09-5b2e5f80eaa4" />


## Solution

use the same config as https://github.com/openfoodfacts/open-prices-frontend/blob/main/.github/workflows/merge-conflict-autolabel.yml