### PR TITLE
feat: add Nutri-Patrol API support

### DIFF
--- a/src/openfoodfacts/api.py
+++ b/src/openfoodfacts/api.py
@@ -145,6 +145,89 @@ class RobotoffResource:
         ).json()
 
 
+class NutriPatrolResource:
+    def __init__(self, api_config: APIConfig):
+        self.api_config = api_config
+        self.base_url = URLBuilder.nutripatrol(environment=api_config.environment)
+
+    def get_flag(self, flag_id: int) -> JSONType:
+        r = http_session.get(f"{self.base_url}/api/v1/flags/{flag_id}")
+        r.raise_for_status()
+        return typing.cast(JSONType, r.json())
+
+    def get_flags(self) -> JSONType:
+        r = http_session.get(f"{self.base_url}/api/v1/flags")
+        r.raise_for_status()
+        return typing.cast(JSONType, r.json())
+
+    def create_flag(self, flag_data: dict) -> JSONType:
+        r = http_session.post(
+            f"{self.base_url}/api/v1/flags",
+            json=flag_data,
+        )
+        r.raise_for_status()
+        return typing.cast(JSONType, r.json())
+
+    def get_flags_by_ticket_batch(self, ticket_ids: list[int]) -> JSONType:
+        r = http_session.post(
+            f"{self.base_url}/api/v1/flags/batch",
+            json={"ticket_ids": ticket_ids},
+        )
+        r.raise_for_status()
+        return typing.cast(JSONType, r.json())
+
+    def get_ticket(self, ticket_id: int) -> JSONType:
+        r = http_session.get(f"{self.base_url}/api/v1/tickets/{ticket_id}")
+        r.raise_for_status()
+        return typing.cast(JSONType, r.json())
+
+    def get_tickets(
+        self,
+        barcode: Optional[str] = None,
+        status: Optional[str] = None,
+        type_: Optional[str] = None,
+        reason: Optional[list[str]] = None,
+        page: int = 1,
+        page_size: int = 10,
+    ) -> JSONType:
+        params: dict = {"page": page, "page_size": page_size}
+        if barcode is not None:
+            params["barcode"] = barcode
+        if status is not None:
+            params["status"] = status
+        if type_ is not None:
+            params["type_"] = type_
+        if reason is not None:
+            params["reason"] = reason
+        r = http_session.get(
+            f"{self.base_url}/api/v1/tickets",
+            params=params,
+        )
+        r.raise_for_status()
+        return typing.cast(JSONType, r.json())
+
+    def update_ticket_status(self, ticket_id: int, status: str) -> JSONType:
+        r = http_session.put(
+            f"{self.base_url}/api/v1/tickets/{ticket_id}/status",
+            params={"status": status},
+        )
+        r.raise_for_status()
+        return typing.cast(JSONType, r.json())
+
+    def get_stats(self, n_days: int = 31) -> JSONType:
+        r = http_session.get(
+            f"{self.base_url}/api/v1/stats",
+            params={"n_days": n_days},
+        )
+        r.raise_for_status()
+        return typing.cast(JSONType, r.json())
+
+    def status(self) -> JSONType:
+        r = http_session.get(f"{self.base_url}/api/v1/status")
+        r.raise_for_status()
+        return typing.cast(JSONType, r.json())
+
+
 class FacetResource:
     def __init__(self, api_config: APIConfig):
         self.api_config = api_config
@@ -676,6 +759,7 @@ class API:
         self.product = ProductResource(self.api_config)
         self.facet = FacetResource(self.api_config)
         self.robotoff = RobotoffResource(self.api_config)
+        self.nutripatrol = NutriPatrolResource(self.api_config)
 
 
 def parse_ingredients(text: str, lang: str, api_config: APIConfig) -> list[JSONType]:

--- a/src/openfoodfacts/utils/__init__.py
+++ b/src/openfoodfacts/utils/__init__.py
@@ -132,6 +132,14 @@ class URLBuilder:
         domain = "net" if environment == Environment.net else "org"
         return f"https://search.openfoodfacts.{domain}"
 
+    @staticmethod
+    def nutripatrol(environment: Environment) -> str:
+        return URLBuilder._get_url(
+            prefix="nutripatrol",
+            tld=environment.value,
+            base_domain=Flavor.off.get_base_domain(),
+        )
+
 
 def jsonl_iter(jsonl_path: Union[str, Path]) -> Iterable[Dict]:
     """Iterate over elements of a JSONL file.


### PR DESCRIPTION
## What
Fixes #323 — adds `NutriPatrolResource` to the Python SDK, exposing 
Nutri-Patrol's moderation API endpoints.

## Changes
- Added `URLBuilder.nutripatrol()` static method in `utils/__init__.py`
  following the existing `robotoff()` pattern
- Added `NutriPatrolResource` class in `api.py` with 9 methods covering
  all endpoints from the real OpenAPI spec:
  - `get_flag(flag_id)` — GET /api/v1/flags/{flag_id}
  - `get_flags()` — GET /api/v1/flags
  - `create_flag(flag_data)` — POST /api/v1/flags
  - `get_flags_by_ticket_batch(ticket_ids)` — POST /api/v1/flags/batch
  - `get_ticket(ticket_id)` — GET /api/v1/tickets/{ticket_id}
  - `get_tickets(...)` — GET /api/v1/tickets (barcode, status, type_, reason, page, page_size)
  - `update_ticket_status(ticket_id, status)` — PUT /api/v1/tickets/{ticket_id}/status
  - `get_stats(n_days)` — GET /api/v1/stats
  - `status()` — GET /api/v1/status
- Wired `self.nutripatrol = NutriPatrolResource(self.api_config)` into `API.__init__`

## Notes
Endpoint signatures were derived directly from the live OpenAPI spec at
https://nutripatrol.openfoodfacts.org/api/openapi.json to ensure accuracy.
All ruff format and ruff check pass cleanly.