### PR TITLE
feat: add support for getting folksonomy tags

### DIFF
--- a/src/openfoodfacts/api.py
+++ b/src/openfoodfacts/api.py
@@ -3,7 +3,7 @@ import logging
 import typing
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
 import requests
 
@@ -376,6 +376,44 @@ class FacetResource:
             method="GET",
         )
         return typing.cast(requests.Response, r).json()
+
+
+class FolksonomyResource:
+    def __init__(self, api_config: APIConfig):
+        self.api_config: APIConfig = api_config
+        self.base_url = URLBuilder.folksonomy(environment=self.api_config.environment)
+
+    def get(
+        self,
+        code: str,
+        owner: str | None = None,
+        keys: Sequence | str | None = None,
+    ) -> requests.Response:
+        """Retrieve folksonomy tags for a product.
+
+        :param code: the product barcode
+        :param owner: the tag owner; requires authentication as that user.
+            Case-sensitive. Leave empty for public tags (default).
+        :param keys: List of keys to filter by. Can be provided as either
+            a Python sequence (list, set, tuple, ...) or as
+            a comma-separated string.
+            If None (the default), all keys are returned.
+        :return: the API response"""
+        params: dict[str, str] = dict()
+        if owner:
+            params["owner"] = owner
+        if keys:
+            if not isinstance(keys, str):
+                keys = ",".join(keys)
+            params["keys"] = keys
+        r = _send_request(
+            url=f"{self.base_url}/product/{code}",
+            api_config=self.api_config,
+            method="GET",
+            params=params,
+        )
+        assert r is not None
+        return r
 
 
 class ProductResource:
@@ -838,6 +876,7 @@ class API:
         self.country = country
         self.product = ProductResource(self.api_config)
         self.facet = FacetResource(self.api_config)
+        self.folksonomy = FolksonomyResource(self.api_config)
         self.robotoff = RobotoffResource(self.api_config)
         self.nutripatrol = NutriPatrolResource(self.api_config)
 

--- a/src/openfoodfacts/utils/__init__.py
+++ b/src/openfoodfacts/utils/__init__.py
@@ -140,6 +140,28 @@ class URLBuilder:
             base_domain=Flavor.off.get_base_domain(),
         )
 
+    @staticmethod
+    def folksonomy(environment: Environment) -> str:
+        """Get API endpoint URL for the Folksonomy Engine.
+
+        Note that this method will always return the "openfoodfacts.org" top domain as
+            SDK users don't need to worry about cookie domains for authentication.
+            This endpoint is project agnostic and will work for all the projects.
+
+        Example use:
+        >>> print(URLBuilder.folksonomy(Environment.net))
+        "https://api.folksonomy.openfoodfacts.net"
+
+        :param environment: Whether to use the production (Environment.org)
+            or staging (Environment.net) environment.
+        :return: The Folksonomy Engine's API endpoint URL as a string.
+        """
+        return URLBuilder._get_url(
+            prefix="api.folksonomy",
+            tld=environment.value,
+            base_domain=Flavor.off.get_base_domain(),
+        )
+
 
 def jsonl_iter(jsonl_path: Union[str, Path]) -> Iterable[Dict]:
     """Iterate over elements of a JSONL file.

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -402,6 +402,75 @@ class TestProducts:
             }
 
 
+class TestFolksonomy:
+    """Unit tests for api.FolksonomyResource and its methods."""
+
+    def test_get_with_entries(self):
+        api = openfoodfacts.API(user_agent=TEST_USER_AGENT)
+        code = "7311043021598"
+        response_data = [
+            {
+                "product": "7311043021598",
+                "k": "ingredients:garlic",
+                "v": "no",
+                "owner": "",
+                "version": 1,
+                "editor": "freso",
+                "last_edit": "2025-11-09T00:30:50.871369",
+                "comment": "",
+            },
+            {
+                "product": "7311043021598",
+                "k": "packaging:has_character",
+                "v": "no",
+                "owner": "",
+                "version": 1,
+                "editor": "freso",
+                "last_edit": "2025-11-09T00:30:44.868444",
+                "comment": "",
+            },
+            {
+                "product": "7311043021598",
+                "k": "weight:net",
+                "v": "75 g",
+                "owner": "",
+                "version": 1,
+                "editor": "freso",
+                "last_edit": "2025-12-03T21:18:22.202625",
+                "comment": "",
+            },
+            {
+                "product": "7311043021598",
+                "k": "weight:net:g",
+                "v": "75",
+                "owner": "",
+                "version": 1,
+                "editor": "freso",
+                "last_edit": "2026-03-03T16:32:03.239368",
+                "comment": "",
+            },
+            {
+                "product": "7311043021598",
+                "k": "weight:net:source",
+                "v": "packaging",
+                "owner": "",
+                "version": 1,
+                "editor": "freso",
+                "last_edit": "2026-03-03T16:32:06.931969",
+                "comment": "",
+            },
+        ]
+        with requests_mock.mock() as mock:
+            mock.get(
+                f"https://api.folksonomy.openfoodfacts.org/product/{code}",
+                text=json.dumps(response_data),
+                status_code=200,
+            )
+            res = api.folksonomy.get(code)
+            assert res.status_code == 200
+            assert len(res.json()) == 5
+
+
 class TestSendRequest:
     """Unit tests for the api._send_request function."""
 


### PR DESCRIPTION
This adds initial extremely basic support for folksonomy tags, namely getting the folksonomy information.

Step 1 in getting full support for folksonomy CRUD functionality. https://github.com/openfoodfacts/openfoodfacts-python/pull/418 adds the rest of the CRUD functions.