### PR TITLE
fix: update text_search endpoint to search v2 API (#496)

### DIFF
--- a/src/openfoodfacts/api.py
+++ b/src/openfoodfacts/api.py
@@ -587,20 +587,18 @@ class ProductResource:
         :param sort_by: result sorting key, defaults to None (no sorting)
         :return: the search results
         """
-        # We force usage of v2 of API
         params = {
             "search_terms": query,
             "page": page,
             "page_size": page_size,
-            "sort_by": sort_by,
-            "json": "1",
         }
 
         if sort_by is not None:
             params["sort_by"] = sort_by
 
+        # Updated endpoint from /cgi/search.pl to /api/v2/search
         r = _send_request(
-            url=f"{self.base_url}/cgi/search.pl",
+            url=f"{self.base_url}/api/v2/search",
             api_config=self.api_config,
             params=params,
             method="GET",

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -86,8 +86,8 @@ class TestProducts:
         with requests_mock.mock() as mock:
             response_data = {"products": ["kinder bueno"], "count": 1}
             mock.get(
-                "https://world.openfoodfacts.org/cgi/search.pl?"
-                + "search_terms=kinder+bueno&json=1&page="
+                "https://world.openfoodfacts.org/api/v2/search?"
+                + "search_terms=kinder+bueno&page="
                 + "1&page_size=20",
                 text=json.dumps(response_data),
             )
@@ -95,8 +95,8 @@ class TestProducts:
             assert res["products"] == ["kinder bueno"]
             response_data = {"products": ["banania", "banania big"], "count": 2}
             mock.get(
-                "https://world.openfoodfacts.org/cgi/search.pl?"
-                + "search_terms=banania&json=1&page="
+                "https://world.openfoodfacts.org/api/v2/search?"
+                + "search_terms=banania&page="
                 + "2&page_size=10&sort_by=unique_scans",
                 text=json.dumps(response_data),
             )


### PR DESCRIPTION
## Description
This PR fixes issue #496 where `text_search` was returning a `503 Server Error` due to the deprecation/blocking of unauthenticated GET requests on the old `/cgi/search.pl` endpoint.

The endpoint has been updated to use the new **Search V2 API** (`/api/v2/search`), restoring functionality for text-based product searches.

## Changes Made
- Updated `text_search` endpoint in `src/openfoodfacts/api.py` from `/cgi/search.pl` to `/api/v2/search`.
- Removed redundant `json=1` parameter as V2 returns JSON by default.
- Updated corresponding unit tests in `tests/unit/test_api.py` to match the new endpoint URL.

## How Has This Been Tested?
- Ran unit tests via `pytest`:
  ```bash
  python -m pytest tests/unit/test_api.py
@hangy 